### PR TITLE
[#7] Grouped orders by price from db loader

### DIFF
--- a/core/scripts/mongo_db/db_utils.py
+++ b/core/scripts/mongo_db/db_utils.py
@@ -2,16 +2,16 @@ import math
 
 
 def order_book_to_dict(order_book):
-
-    flattened_ask_book = [
-        item for sublist in order_book.ask_book.values() for item in sublist]
-    flattened_bid_book = [
-        item for sublist in order_book.ask_book.values() for item in sublist]
-
     return {
         "instrument": order_book.instrument,
-        "bids": [order_to_dict(bid) for bid in sorted(flattened_bid_book, key=lambda x: -x.price)],
-        "asks": [order_to_dict(ask) for ask in sorted(flattened_ask_book, key=lambda x: x.price)],
+        "bids": [{
+            "price": price,
+            "orders": [order_to_dict(order) for order in orders]
+        } for price, orders in sorted(order_book.bid_book.items(), reverse=True)],
+        "asks": [{
+            "price": price,
+            "orders": [order_to_dict(order) for order in orders]
+        } for price, orders in sorted(order_book.ask_book.items())],
         "timestamp": _round_up(order_book.last_time, 9)
     }
 
@@ -19,8 +19,7 @@ def order_book_to_dict(order_book):
 def order_to_dict(order):
     return {
         "id": order.id,
-        "quantity": order.qty,
-        "price": order.price
+        "quantity": order.qty
     }
 
 


### PR DESCRIPTION
Orderbooks now have the following structure:
```javascript
{
  "timestamp": <iso-something>,
  "bids": [
    { // A price-level item
      "price": float,
      "orders": [
        { // An order item
          "id": bigint,
          "quantity": int
        },
        ... // More orders, sorted according to their position in the priority queue
      ]
    },
    ... // More price-levels, sorted by price
  ],
  "asks": <same as bids, price-levels sorted in opposite direction>
}
```
IMPORTANT: drop all db data and rerun data importer script