### PR TITLE
[#26] Added ui tests for date and time picker

### DIFF
--- a/app/src/components/OrderBookSnapshot.js
+++ b/app/src/components/OrderBookSnapshot.js
@@ -56,7 +56,7 @@ class OrderBookSnapshot extends Component {
         this.setState({
             selectedDateNano: selectedDateNano,
         }, () => {this.handleChangeDateTime();});
-    }
+    };
 
     /**
      * Handles the time change when sliding the time Slider
@@ -72,7 +72,7 @@ class OrderBookSnapshot extends Component {
             selectedTimeNano: selectedTimeNano,
             selectedTimeString: nanosecondsToString(selectedTimeNano),
         });
-    }
+    };
 
     /**
      * Handles the time change when the user stops sliding the time Slider
@@ -87,7 +87,7 @@ class OrderBookSnapshot extends Component {
             selectedTimeNano: selectedTimeNano,
             selectedTimeString: nanosecondsToString(selectedTimeNano),
         }, () => {this.handleChangeDateTime();});
-    }
+    };
 
     /**
      * Updates the selectedDateTimeNano state variable when there is a change in the date or when the user stops sliding the time Slider
@@ -99,7 +99,7 @@ class OrderBookSnapshot extends Component {
         this.setState({
             selectedDateTimeNano: selectedDateTimeNano,
         });
-    }
+    };
 
     render() {
         const {classes} = this.props;

--- a/app/src/tests/component-tests/OrderBookSnapshot.test.js
+++ b/app/src/tests/component-tests/OrderBookSnapshot.test.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import OrderBookSnapshot from '../../components/OrderBookSnapshot';
+import {createMount, createShallow} from '@material-ui/core/test-utils';
+import { TextField } from '@material-ui/core';
+import {DATE_STRING, TIME_VALUE, TIME_STRING, DATE_VALUE} from '../utils/mock-data';
+import OrderBookService from '../../services/OrderBookService';
+
+describe('date and time picker functionality', () => {
+    let mount, shallow;
+    const orderBookServiceSpy = jest.spyOn(OrderBookService, 'getOrderBookPrices').mockImplementation((instrument, timestamp) => Promise.resolve({ data: () => [] }));
+
+    beforeEach(() => {
+        mount = createMount();
+        shallow = createShallow({dive: true});
+    });
+
+    afterEach(() => {
+        orderBookServiceSpy.mockClear();
+        mount.cleanUp();
+    });
+
+    it('renders an OrderBookSnapshot component without crashing', () => {
+        const wrapper = mount(<OrderBookSnapshot/>);
+    });
+
+    it('makes database call once a date and time are selected, in order', () => {
+        const wrapper = shallow(<OrderBookSnapshot/>);
+
+        wrapper.find(TextField).simulate('change', { target: { value: DATE_STRING } });
+        expect(orderBookServiceSpy).toHaveBeenCalledTimes(0);
+
+        wrapper.instance().handleCommitTime('change', TIME_VALUE);
+        expect(orderBookServiceSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('makes database call once a time and date are selected, in order', () => {
+        const wrapper = shallow(<OrderBookSnapshot/>);
+
+        wrapper.instance().handleCommitTime('change', TIME_VALUE);
+        expect(orderBookServiceSpy).toHaveBeenCalledTimes(0);
+
+        wrapper.find(TextField).simulate('change', { target: { value: DATE_STRING } });
+        expect(orderBookServiceSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should store the proper time string when the time is selected', () => {
+        const wrapper = shallow(<OrderBookSnapshot/>);
+
+        wrapper.instance().handleCommitTime('change', TIME_VALUE);
+
+        const selectedTimeString = wrapper.state().selectedTimeString;
+        expect(selectedTimeString).toEqual(TIME_STRING);
+    });
+
+    it('should store the proper date value in nanoseconds when the date is selected', () => {
+        const wrapper = shallow(<OrderBookSnapshot/>);
+
+        wrapper.find(TextField).simulate('change', { target: { value: DATE_STRING } });
+
+        const selectedDateNano = wrapper.state().selectedDateNano;
+        expect(selectedDateNano).toEqual(DATE_VALUE);
+    });
+
+    it('should store the proper epoch timestamp in nanoseconds when the date and time are selected', () => {
+        const wrapper = shallow(<OrderBookSnapshot/>);
+
+        wrapper.find(TextField).simulate('change', { target: { value: DATE_STRING } });
+        wrapper.instance().handleCommitTime('change', TIME_VALUE);
+
+        const selectedDateNano = wrapper.state().selectedDateTimeNano;
+        expect(selectedDateNano).toEqual(DATE_VALUE+TIME_VALUE);
+    });
+});

--- a/app/src/tests/component-tests/OrderBookSnapshot.test.js
+++ b/app/src/tests/component-tests/OrderBookSnapshot.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import OrderBookSnapshot from '../../components/OrderBookSnapshot';
 import {createMount, createShallow} from '@material-ui/core/test-utils';
-import { TextField } from '@material-ui/core';
+import { TextField, Slider } from '@material-ui/core';
 import {DATE_STRING, TIME_VALUE, TIME_STRING, DATE_VALUE} from '../utils/mock-data';
 import OrderBookService from '../../services/OrderBookService';
 
@@ -29,12 +29,18 @@ describe('date and time picker functionality', () => {
         wrapper.find(TextField).simulate('change', { target: { value: DATE_STRING } });
         expect(orderBookServiceSpy).toHaveBeenCalledTimes(0);
 
+        wrapper.find(Slider).simulate('change', TIME_VALUE);
+        expect(orderBookServiceSpy).toHaveBeenCalledTimes(0);
+
         wrapper.instance().handleCommitTime('change', TIME_VALUE);
         expect(orderBookServiceSpy).toHaveBeenCalledTimes(1);
     });
 
     it('makes database call once a time and date are selected, in order', () => {
         const wrapper = shallow(<OrderBookSnapshot/>);
+
+        wrapper.find(Slider).simulate('change', TIME_VALUE);
+        expect(orderBookServiceSpy).toHaveBeenCalledTimes(0);
 
         wrapper.instance().handleCommitTime('change', TIME_VALUE);
         expect(orderBookServiceSpy).toHaveBeenCalledTimes(0);

--- a/app/src/tests/utils/mock-data.js
+++ b/app/src/tests/utils/mock-data.js
@@ -99,3 +99,8 @@ export const ORDERBOOK_FROM_BACKEND = {
                 }]
         }]
 };
+
+export const DATE_STRING = '2012-06-21';
+export const DATE_VALUE = 1340236800000000000; // 2012-06-21 UTC in epoch nanoseconds
+export const TIME_STRING = '12:00:00.000000000';
+export const TIME_VALUE = 43200000000000; // number of nanoseconds in 12 hours


### PR DESCRIPTION
Added OrderBookSnapshot.test.js for testing the behavior of the date and time picker.

- Checks that api call is only made only when date and time are selected. Checks that the api call is only made when the time is committed (when the user lets go of the slider).

- Checks that the state has the proper nanosecond and string values when date or time is selected