### PR TITLE
[#55] Added golangci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-    build:
+    build_app:
         machine:
             image: ubuntu-1604:201903-01
         steps:
@@ -11,18 +11,6 @@ jobs:
             - run:
                   name: Build docker image for frontend testing
                   command: docker build --target=test -t graphelier-app-test ./app
-
-            - run:
-                  name: Build docker image for backend linting
-                  command: docker build --target=lint -t graphelier-service-lint ./core
-
-            - run:
-                  name: Build docker image for scripts linting
-                  command: docker build --target=lint -t graphelier-scripts-lint ./core/scripts
-            - run:
-                  name: Build docker image for scripts testing
-                  command: docker build --target=test -t graphelier-scripts-test ./core/scripts
-
             - run:
                   name: Run the container for frontend linting
                   command: docker run graphelier-app-lint
@@ -30,13 +18,40 @@ jobs:
                   name: Run the container for frontend testing
                   command: docker run graphelier-app-test
 
+    build_service:
+        machine:
+            image: ubuntu-1604:201903-01
+        steps:
+            - checkout
             - run:
-                  name: Run the container for backend linting
-                  command: docker run graphelier-service-lint
+                  name: Build docker image for backend testing
+                  command: docker build --target=test -t graphelier-service-test ./core
+            - run:
+                  name: Run the container for backend testing
+                  command: docker run graphelier-service-test
 
+    build_scripts:
+        machine:
+            image: ubuntu-1604:201903-01
+        steps:
+            - checkout
+            - run:
+                  name: Build docker image for scripts linting
+                  command: docker build --target=lint -t graphelier-scripts-lint ./core/scripts
+            - run:
+                  name: Build docker image for scripts testing
+                  command: docker build --target=test -t graphelier-scripts-test ./core/scripts
             - run:
                   name: Run the container for scripts linting
                   command: docker run graphelier-scripts-lint
             - run:
                   name: Run the container for scripts testing
                   command: docker run graphelier-scripts-test
+
+workflows:
+    version: 2
+    build_and_test:
+        jobs:
+            - build_app
+            - build_service
+            - build_scripts

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+# https://github.com/golangci/golangci/wiki/Configuration
+
+# Paths here are very specific: the build process will copy the source into `/go/src/{project-path}`
+# All commands are run from that directory
+service:
+  project-path: graphelier/
+  analyzed-paths:
+    - core/graphelier-service/...
+  prepare:
+    - go get graphelier/core/graphelier-service

--- a/README.md
+++ b/README.md
@@ -1,45 +1,10 @@
-# Graphelier
+# Graphelier [![CircleCI](https://circleci.com/gh/Lercerss/graphelier.svg?style=svg&circle-token=50dd302111fbcd79ed4503e7970d95ef963b155e)](https://circleci.com/gh/Lercerss/graphelier)
 
-[![CircleCI](https://circleci.com/gh/Lercerss/graphelier.svg?style=svg&circle-token=50dd302111fbcd79ed4503e7970d95ef963b155e)](https://circleci.com/gh/Lercerss/graphelier)
 Displays detailed exchange order book contents
 
 ## Running the Application
 
 ```sh
+docker-compose build
 docker-compose up
-```
-
-## Running the frontend linter with docker
-
-```sh
-docker build --target=lint -t graphelier-app-lint ./app
-docker run graphelier-app-lint
-```
-
-## Running the frontend tests with docker
-
-```sh
-docker build --target=test -t graphelier-app-test ./app
-docker run graphelier-app-test
-```
-
-## Running the backend linter with docker
-
-```sh
-docker build --target=lint -t graphelier-service-test ./core
-docker run graphelier-service-test
-```
-
-## Running the python scripts linter with docker
-
-```sh
-docker build --target=lint -t graphelier-scripts-lint ./core/scripts
-docker run graphelier-scripts-lint
-```
-
-## Running the python scripts' tests with docker
-
-```sh
-docker build --target=test -t graphelier-scripts-test ./core/scripts
-docker run graphelier-scripts-test
 ```

--- a/app/README.md
+++ b/app/README.md
@@ -24,6 +24,20 @@ The page will reload if you make edits.
 #### `npm test`
 Launches the test runner in the interactive watch mode. See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
 
+## Running the frontend linter with docker
+
+```sh
+docker build --target=lint -t graphelier-app-lint ./app
+docker run graphelier-app-lint
+```
+
+## Running the frontend tests with docker
+
+```sh
+docker build --target=test -t graphelier-app-test ./app
+docker run graphelier-app-test
+```
+
 ###  Development
 
 #### Coding Standards

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -5,11 +5,9 @@ FROM base AS builder
 RUN apk add --no-cache build-base git mercurial
 COPY graphelier-service .
 RUN go get graphelier/core/graphelier-service
-RUN go install ...
 
-FROM builder AS lint
-RUN wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.20.0 -b /bin
-CMD [ "./bin/golangci-lint", "run" ]
+FROM builder AS test
+CMD ["go", "test", "graphelier/core/graphelier-service/..."]
 
 FROM builder AS dev
 RUN go get github.com/pilu/fresh

--- a/core/README.md
+++ b/core/README.md
@@ -14,7 +14,7 @@ All commands should be run from the `core/` directory. This repo should be place
 Build and install the service executable inside your go `bin` directory:
 
 ```bash
-go install ...
+go get graphelier/core/graphelier-service
 ```
 
 ### Launching graphelier-service
@@ -26,7 +26,13 @@ $GOPATH/bin/graphelier-service
 ### Testing
 
 ```bash
-go test ...
+go test graphelier/core/graphelier-service/...
+```
+
+### Linting
+
+```bash
+go fmt graphelier/core/graphelier-service/...
 ```
 
 ## Scripts
@@ -39,4 +45,18 @@ Load data from file containing messages
 
 ```bash
 python -m importer <path_to_messages_file> <start_time>
+```
+
+### Linting with docker
+
+```sh
+docker build --target=lint -t graphelier-scripts-lint ./core/scripts
+docker run graphelier-scripts-lint
+```
+
+### Running tests with docker
+
+```sh
+docker build --target=test -t graphelier-scripts-test ./core/scripts
+docker run graphelier-scripts-test
 ```


### PR DESCRIPTION
- Modified circleci config to run jobs by component
- Moved README contents
- Added test step for service

Linting for the service is now executed by GolangCI instead of a step in CircleCI. Code styling is still enforced according to `go fmt` standards. I will add it to required checks on PRs.

Failed builds for a component should no longer prevent the build step for other components from executing.