### PR TITLE
[#65] Timestamp gets converted to UTC

### DIFF
--- a/app/.eslintrc.json
+++ b/app/.eslintrc.json
@@ -14,6 +14,8 @@
         "camelcase": "error",
         "quotes": ["error", "single", { "allowTemplateLiterals": true }],
         "no-template-curly-in-string": "error",
-        "no-multi-spaces": "error"
-    }
+        "no-multi-spaces": "error",
+        "react/jsx-max-props-per-line": [1, { "maximum": 1 }]
+    },
+    "plugins": ["react"]
 }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -5499,25 +5499,27 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.14.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
-      "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz",
+      "integrity": "sha512-GacBAATewhhptbK3/vTP09CbFrgUJmBSaaRcWdbQLFvUZy9yVcQxigBNHGPU/KE2AyHpzj3AWXpxoMTsIDiHug==",
+      "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.1.0",
+        "jsx-ast-utils": "^2.2.1",
         "object.entries": "^1.1.0",
         "object.fromentries": "^2.0.0",
         "object.values": "^1.1.0",
         "prop-types": "^15.7.2",
-        "resolve": "^1.10.1"
+        "resolve": "^1.12.0"
       },
       "dependencies": {
         "doctrine": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
           "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
           "requires": {
             "esutils": "^2.0.2"
           }
@@ -9563,14 +9565,33 @@
       }
     },
     "object.fromentries": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
-      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
+      "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.11.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.15.0",
         "function-bind": "^1.1.1",
-        "has": "^1.0.1"
+        "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+          "integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
+          "requires": {
+            "es-to-primitive": "^1.2.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.0",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.6.0",
+            "object-keys": "^1.1.1",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -11401,6 +11422,32 @@
             "table": "^5.2.3",
             "text-table": "^0.2.0",
             "v8-compile-cache": "^2.0.3"
+          }
+        },
+        "eslint-plugin-react": {
+          "version": "7.14.3",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
+          "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
+          "requires": {
+            "array-includes": "^3.0.3",
+            "doctrine": "^2.1.0",
+            "has": "^1.0.3",
+            "jsx-ast-utils": "^2.1.0",
+            "object.entries": "^1.1.0",
+            "object.fromentries": "^2.0.0",
+            "object.values": "^1.1.0",
+            "prop-types": "^15.7.2",
+            "resolve": "^1.10.1"
+          },
+          "dependencies": {
+            "doctrine": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+              "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+              "requires": {
+                "esutils": "^2.0.2"
+              }
+            }
           }
         },
         "eslint-scope": {

--- a/app/package.json
+++ b/app/package.json
@@ -33,6 +33,7 @@
         "enzyme": "^3.10.0",
         "enzyme-adapter-react-16": "^1.15.1",
         "eslint": "^6.4.0",
+        "eslint-plugin-react": "^7.16.0",
         "react-test-renderer": "^16.10.2"
     },
     "browserslist": {

--- a/app/src/components/Order.js
+++ b/app/src/components/Order.js
@@ -13,12 +13,24 @@ class Order extends Component {
         const minQuantityTextSize = 1.5;
 
         return (
-            quantityBoxSize > minQuantityTextSize ?
-                <Box className={classNames(classes.rectangle, type === 'bid' ? classes.bid : classes.ask)} style={{ minWidth: `${quantityBoxSize}%`, maxWidth: `${quantityBoxSize}%` }}>
+            quantityBoxSize > minQuantityTextSize ? (
+                <Box 
+                    className={classNames(classes.rectangle, type === 'bid' ? classes.bid : classes.ask)}
+                    style={{ minWidth: `${quantityBoxSize}%`, maxWidth: `${quantityBoxSize}%` }}
+                >
                     <Typography className={classes.text}>{quantity}</Typography>
-                </Box> :
-                <Tooltip title={quantity} placement='cursor'><span className={`${classes.quantity} ${classNames(classes.rectangle, type === 'bid' ? classes.bid : classes.ask)}`} style={{ minWidth: `${quantityBoxSize}%`, maxWidth: `${quantityBoxSize}%` }}/>
+                </Box>
+            ) : (
+                <Tooltip
+                    title={quantity}
+                    placement='cursor'
+                >
+                    <span
+                        className={`${classes.quantity} ${classNames(classes.rectangle, type === 'bid' ? classes.bid : classes.ask)}`}
+                        style={{ minWidth: `${quantityBoxSize}%`, maxWidth: `${quantityBoxSize}%` }}
+                    />
                 </Tooltip>
+            )
         );
     }
 }

--- a/app/src/components/OrderBookSnapshot.js
+++ b/app/src/components/OrderBookSnapshot.js
@@ -1,18 +1,32 @@
 import React, { Component } from 'react';
-import { withStyles, Typography, FormControl, TextField, Slider, Collapse, IconButton, Card } from '@material-ui/core';
+import {
+    withStyles,
+    Typography,
+    FormControl,
+    TextField,
+    Slider,
+    Collapse,
+    IconButton,
+    Card
+} from '@material-ui/core';
 import { Styles } from '../styles/OrderBookSnapshot';
-import { dateStringToEpoch, nanosecondsToString } from '../utils/date-utils';
+import {
+    dateStringToEpoch,
+    nanosecondsToString,
+    convertNanosecondsToUTC
+} from '../utils/date-utils';
 import TimestampOrderBookScroller from './TimestampOrderBookScroller';
 import classNames from 'classnames';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
-
 import OrderBookService from '../services/OrderBookService';
-import { SNAPSHOT_INSTRUMENT, NANOSECONDS_IN_NINE_AND_A_HALF_HOURS, NANOSECONDS_IN_SIXTEEN_HOURS } from '../constants/Constants';
-
+import {
+    SNAPSHOT_INSTRUMENT,
+    NANOSECONDS_IN_NINE_AND_A_HALF_HOURS,
+    NANOSECONDS_IN_SIXTEEN_HOURS
+} from '../constants/Constants';
 
 class OrderBookSnapshot extends Component {
-
     constructor(props) {
         super(props);
 
@@ -31,12 +45,17 @@ class OrderBookSnapshot extends Component {
      * @desc Handles the date change for the TextField date picker
      * @param event The event object that caused the call
      */
-    handleChangeDate = (event) => {
+    handleChangeDate = event => {
         let selectedDateNano = parseInt(dateStringToEpoch(event.target.value + ' 00:00:00'));
 
-        this.setState({
-            selectedDateNano,
-        }, () => { this.handleChangeDateTime(); });
+        this.setState(
+            {
+                selectedDateNano
+            },
+            () => {
+                this.handleChangeDateTime();
+            }
+        );
     };
 
     /**
@@ -49,7 +68,7 @@ class OrderBookSnapshot extends Component {
 
         this.setState({
             selectedTimeNano: selectedTimeNano,
-            selectedTimeString: nanosecondsToString(selectedTimeNano),
+            selectedTimeString: nanosecondsToString(selectedTimeNano)
         });
     };
 
@@ -62,13 +81,16 @@ class OrderBookSnapshot extends Component {
         const { selectedDateNano } = this.state;
 
         let selectedTimeNano = parseInt(value);
-        let selectedDateTimeNano = selectedTimeNano + selectedDateNano;
+        let selectedDateTimeNano = convertNanosecondsToUTC(selectedTimeNano + selectedDateNano);
 
-        this.setState({
-            selectedTimeNano,
-            selectedTimeString: nanosecondsToString(selectedTimeNano),
-            selectedDateTimeNano
-        }, () => this.handleChangeDateTime());
+        this.setState(
+            {
+                selectedTimeNano,
+                selectedTimeString: nanosecondsToString(selectedTimeNano),
+                selectedDateTimeNano
+            },
+            () => this.handleChangeDateTime()
+        );
     };
 
     /**
@@ -83,7 +105,7 @@ class OrderBookSnapshot extends Component {
                 .then(response => {
                     this.setState({
                         asks: response.data.asks,
-                        bids: response.data.bids,
+                        bids: response.data.bids
                     });
                 })
                 .catch(err => {
@@ -103,21 +125,27 @@ class OrderBookSnapshot extends Component {
         const { classes } = this.props;
         const { asks, bids, expanded } = this.state;
         return (
-            <Typography component={'div'} className={classes.container}>
+            <Typography
+                component={'div'}
+                className={classes.container}
+            >
                 <div className={classNames(classes.spaceBetween, classes.flex)}>
-                    {(this.state.selectedTimeNano === 0 || this.state.selectedDateNano === 0) ?
+                    {this.state.selectedTimeNano === 0 || this.state.selectedDateNano === 0 ? (
                         <Typography
                             variant={'body1'}
-                            className={classNames(classes.pleaseSelectMessage, classes.flex)}>
+                            className={classNames(classes.pleaseSelectMessage, classes.flex)}
+                        >
                             Please select Date and Time
-                        </Typography> :
+                        </Typography>
+                    ) : (
                         <Typography
                             variant={'body1'}
                             color={'textPrimary'}
-                            className={classNames(classes.selectMessage, classes.flex)}>
+                            className={classNames(classes.selectMessage, classes.flex)}
+                        >
                             Select Date and Time
                         </Typography>
-                    }
+                    )}
                     <IconButton
                         className={classNames(classes.expand, expanded && classes.expandOpen)}
                         onClick={this.handleExpandClick}
@@ -128,13 +156,17 @@ class OrderBookSnapshot extends Component {
                     </IconButton>
                 </div>
                 <Collapse in={expanded}>
-                    <div id={'ButtonHeader'} className={classes.divTopBook}>
+                    <div
+                        id={'ButtonHeader'}
+                        className={classes.divTopBook}
+                    >
                         <FormControl className={classes.formControl}>
                             <div className={classes.inline}>
                                 <Typography
                                     variant={'body1'}
                                     className={classNames(classes.inputLabel)}
-                                    color={'textSecondary'}>
+                                    color={'textSecondary'}
+                                >
                                     {'Date'}
                                 </Typography>
                                 <TextField
@@ -147,19 +179,22 @@ class OrderBookSnapshot extends Component {
                                 <Typography
                                     variant={'body1'}
                                     className={classes.inputLabel}
-                                    color={'textSecondary'}>
+                                    color={'textSecondary'}
+                                >
                                     {'Time'}
                                 </Typography>
                                 <Typography
                                     variant={'body1'}
-                                    className={classes.timestampDisplay}>
+                                    className={classes.timestampDisplay}
+                                >
                                     {this.state.selectedTimeString}
                                 </Typography>
                             </div>
                             <div className={classes.inline}>
-                                <Typography
+                                <Typography 
                                     variant={'body1'}
-                                    color={'textSecondary'}>
+                                    color={'textSecondary'}
+                                >
                                     9:30
                                 </Typography>
                                 <Slider
@@ -173,7 +208,8 @@ class OrderBookSnapshot extends Component {
                                 />
                                 <Typography
                                     variant={'body1'}
-                                    color={'textSecondary'}>
+                                    color={'textSecondary'}
+                                >
                                     16:00
                                 </Typography>
                             </div>
@@ -181,9 +217,7 @@ class OrderBookSnapshot extends Component {
                     </div>
                 </Collapse>
                 <Card>
-                    <TimestampOrderBookScroller
-                        orderBook={{ asks, bids }}
-                    />
+                    <TimestampOrderBookScroller orderBook={{ asks, bids }} />
                 </Card>
             </Typography>
         );

--- a/app/src/components/template/Dashboard.js
+++ b/app/src/components/template/Dashboard.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import clsx from 'clsx';
+import classNames from 'classnames';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { Drawer, AppBar, Toolbar, List, Typography, Divider, IconButton, Container} from '@material-ui/core';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
@@ -33,18 +33,28 @@ const Dashboard = () => {
     return (
         <div className={classes.root}>
             <CssBaseline />
-            <AppBar position={'absolute'} className={clsx(classes.appBar, open && classes.appBarShift)} theme={OBStyles.themeBackground}>
+            <AppBar 
+                position={'absolute'}
+                className={classNames(classes.appBar, open && classes.appBarShift)}
+                theme={OBStyles.themeBackground}
+            >
                 <Toolbar className={classes.toolbar}>
                     <IconButton
                         edge={'start'}
                         color={'inherit'}
                         aria-label={'open drawer'}
                         onClick={handleDrawerOpen}
-                        className={clsx(classes.menuButton, open && classes.menuButtonHidden)}
+                        className={classNames(classes.menuButton, open && classes.menuButtonHidden)}
                     >
                         <MenuIcon />
                     </IconButton>
-                    <Typography component={'h1'} variant={'h6'} color={'inherit'} noWrap className={classes.title}>
+                    <Typography
+                        component={'h1'}
+                        variant={'h6'}
+                        color={'inherit'}
+                        noWrap
+                        className={classes.title}
+                    >
                         Graphelier
                     </Typography>
                 </Toolbar>
@@ -52,7 +62,7 @@ const Dashboard = () => {
             <Drawer
                 variant={'permanent'}
                 classes={{
-                    paper: clsx(classes.drawerPaper, !open && classes.drawerPaperClose),
+                    paper: classNames(classes.drawerPaper, !open && classes.drawerPaperClose),
                 }}
                 open={open}
             >

--- a/app/src/utils/date-utils.js
+++ b/app/src/utils/date-utils.js
@@ -1,7 +1,7 @@
 import NanoDate from 'nano-date';
 import moment from 'moment';
 
-import {NANOSECONDS_IN_ONE_SECOND} from '../constants/Constants';
+import { NANOSECONDS_IN_ONE_SECOND } from '../constants/Constants';
 
 /**
  * @desc formats given date in the format YYYY-MM-DD HH:mm:ssZ into human readable at nanosecond precision
@@ -9,8 +9,7 @@ import {NANOSECONDS_IN_ONE_SECOND} from '../constants/Constants';
  * @param date
  * @returns {string}
  */
-export const getFormattedDate = (date) => {
-
+export const getFormattedDate = date => {
     const dateObj = moment(date);
     const nanoDate = new NanoDate(dateObj.valueOf());
     let entries = nanoDate.toString().split(' ');
@@ -23,7 +22,7 @@ export const getFormattedDate = (date) => {
  * @param date
  * @returns {string}
  */
-export const dateStringToEpoch = (date) => {
+export const dateStringToEpoch = date => {
     const dateObj = moment.utc(date);
     const nanoDate = new NanoDate(dateObj.valueOf());
     return nanoDate.getTime();
@@ -34,12 +33,29 @@ export const dateStringToEpoch = (date) => {
  * @param nanosecondTimestamp
  * @returns {string}
  */
-export const nanosecondsToString = (nanosecondTimestamp) => {
+export const nanosecondsToString = nanosecondTimestamp => {
+    let nanoseconds = Math.floor(nanosecondTimestamp % NANOSECONDS_IN_ONE_SECOND);
+    let seconds = Math.floor((nanosecondTimestamp / NANOSECONDS_IN_ONE_SECOND) % 60);
+    let minutes = Math.floor((nanosecondTimestamp / (NANOSECONDS_IN_ONE_SECOND * 60)) % 60);
+    let hours = Math.floor((nanosecondTimestamp / (NANOSECONDS_IN_ONE_SECOND * 60 * 60)) % 24);
 
-    let nanoseconds = Math.floor(nanosecondTimestamp%NANOSECONDS_IN_ONE_SECOND);
-    let seconds = Math.floor((nanosecondTimestamp/NANOSECONDS_IN_ONE_SECOND)%60);
-    let minutes = Math.floor((nanosecondTimestamp/(NANOSECONDS_IN_ONE_SECOND*60))%60);
-    let hours = Math.floor((nanosecondTimestamp/(NANOSECONDS_IN_ONE_SECOND*60*60))%24);
+    return (
+        hours.toString().padStart(2, '0') +
+        ':' +
+        minutes.toString().padStart(2, '0') +
+        ':' +
+        seconds.toString().padStart(2, '0') +
+        '.' +
+        nanoseconds.toString().padStart(9, '0')
+    );
+};
 
-    return hours.toString().padStart(2, '0') + ':' + minutes.toString().padStart(2, '0') + ':' + seconds.toString().padStart(2, '0') + '.' + nanoseconds.toString().padStart(9, '0');
+/**
+ * @desc Given a timestamp in nanoseconds, returns the timestamp converted to UTC
+ * @param nanosecondTimestamp
+ * @returns {Number}
+ */
+export const convertNanosecondsToUTC = nanosecondTimestamp => {
+    let offsetNS = new Date().getTimezoneOffset() * 60 * 10 ** 9;
+    return nanosecondTimestamp + offsetNS;
 };

--- a/core/graphelier-service/api/hndlrs/obhandler.go
+++ b/core/graphelier-service/api/hndlrs/obhandler.go
@@ -43,12 +43,12 @@ func JSONOrderbook(env *Env, w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
+	w.WriteHeader(http.StatusOK)
 	err = json.NewEncoder(w).Encode(orderbook)
 	if err != nil {
 		return err
 	}
 
-	w.WriteHeader(http.StatusOK)
 
 	return nil
 }


### PR DESCRIPTION
Added a rule in eslint to enforce the 1-prop-per-line rule.
Also, server was complaining about writing the header after writing the response so I changed the ordering on the backend.
Most important part of this PR is the `handleCommitTime` method in OrderBookSnapshot.js and the `convertNanosecondsToUTC` in date-utils.js.