### PR TITLE
[#51] Serving messages with pagination

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
                   at: /go/src/graphelier
             - run:
                   name: Build service executable
-                  command: go get graphelier/core/graphelier-service
+                  command: go get -t graphelier/core/graphelier-service/...
             - save_cache:
                   key: v2-service-{{ .Branch }}
                   paths:

--- a/core/graphelier-service/api/hndlrs/handlers.go
+++ b/core/graphelier-service/api/hndlrs/handlers.go
@@ -31,7 +31,7 @@ func (se StatusError) Status() int {
 
 // Env : A struct that represents the database configuration
 type Env struct {
-	Connector *db.Connector
+	Connector db.Datastore
 }
 
 // CustomHandler : A struct that links Env with a function matching http.HandlerFunc

--- a/core/graphelier-service/api/hndlrs/msghandler.go
+++ b/core/graphelier-service/api/hndlrs/msghandler.go
@@ -1,0 +1,52 @@
+package hndlrs
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"graphelier/core/graphelier-service/models"
+
+	"github.com/gorilla/mux"
+)
+
+// FetchMessages returns messages given an instrument and sod_offset with support for
+// pagination
+func FetchMessages(env *Env, w http.ResponseWriter, r *http.Request) error {
+	nMessages := r.URL.Query().Get("nMessages")
+
+	params := mux.Vars(r)
+	instrument := params["instrument"]
+	sodOffset := params["sodOffset"]
+
+	intNMessages, err := strconv.ParseInt(nMessages, 10, 8)
+	if err != nil {
+		intNMessages = 20
+	}
+
+	intSodOffset, err := strconv.ParseInt(sodOffset, 10, 64)
+	if err != nil {
+		return StatusError{400, err}
+	}
+	paginator := models.Paginator{NMessages: intNMessages, SodOffset: intSodOffset}
+	messages, err := env.Connector.GetMessagesWithPagination(instrument, intSodOffset, &paginator)
+	if err != nil {
+		return StatusError{500, err}
+	}
+	messagePage := models.MessagePage{PageInfo: paginator, Messages: messages}
+	if intNMessages < 0 {
+		reverseMessageOrdering(&messagePage)
+	}
+	w.WriteHeader(http.StatusOK)
+	err = json.NewEncoder(w).Encode(messagePage)
+	if err != nil {
+		return StatusError{500, err}
+	}
+	return nil
+}
+
+func reverseMessageOrdering(messagePage *models.MessagePage) {
+	for i, j := 0, len(messagePage.Messages)-1; i < j; i, j = i+1, j-1 {
+		messagePage.Messages[i], messagePage.Messages[j] = messagePage.Messages[j], messagePage.Messages[i]
+	}
+}

--- a/core/graphelier-service/api/hndlrs/msghandler_test.go
+++ b/core/graphelier-service/api/hndlrs/msghandler_test.go
@@ -1,0 +1,134 @@
+package hndlrs
+
+import (
+	"encoding/json"
+	"graphelier/core/graphelier-service/models"
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gorilla/mux"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type mockDB struct {
+	mock.Mock
+}
+
+func (db *mockDB) GetOrderbook(instrument string, timestamp uint64) (*models.Orderbook, error) {
+	return &models.Orderbook{}, nil
+}
+func (db *mockDB) GetMessages(instrument string, timestamp uint64, latestFullSnapshot uint64) ([]*models.Message, error) {
+	messages := make([]*models.Message, 0)
+	return messages, nil
+}
+func (db *mockDB) GetMessagesWithPagination(instrument string, timestamp int64, paginator *models.Paginator) ([]*models.Message, error) {
+	db.Called(instrument, timestamp, paginator)
+	messages := make([]*models.Message, 0)
+	messages = append(messages, &models.Message{Direction: -1, Instrument: "test", MessageType: 1, OrderID: 12, Price: 100, ShareQuantity: 10, Timestamp: 100, SodOffset: 1})
+	messages = append(messages, &models.Message{Direction: -1, Instrument: "test", MessageType: 1, OrderID: 13, Price: 100, ShareQuantity: 10, Timestamp: 100, SodOffset: 2})
+	return messages, nil
+}
+
+func TestFetchMessagesSuccess(t *testing.T) {
+	mockedDB := &mockDB{}
+	mockedEnv := &Env{mockedDB}
+	req := httptest.NewRequest("GET", "/messages/test/100?nMessages=25", nil)
+	vars := map[string]string{
+		"instrument": "test",
+		"sodOffset":  "100",
+	}
+	req = mux.SetURLVars(req, vars)
+	writer := httptest.NewRecorder()
+	mockedDB.On("GetMessagesWithPagination", "test", int64(100), &models.Paginator{SodOffset: 100, NMessages: 25})
+
+	err := FetchMessages(mockedEnv, writer, req)
+	resp := writer.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
+	var messagePage models.MessagePage
+	json.Unmarshal(body, &messagePage)
+	mockedDB.AssertCalled(t, "GetMessagesWithPagination", "test", int64(100), &models.Paginator{SodOffset: 100, NMessages: 25})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(25), messagePage.PageInfo.NMessages)
+	assert.Equal(t, int64(100), messagePage.PageInfo.SodOffset)
+	assert.Equal(t, uint64(12), messagePage.Messages[0].OrderID)
+}
+
+func TestFetchMessagesDefaultValues(t *testing.T) {
+	mockedDB := &mockDB{}
+	mockedEnv := &Env{mockedDB}
+	req := httptest.NewRequest("GET", "/messages/test/100", nil)
+	vars := map[string]string{
+		"instrument": "test",
+		"sodOffset":  "100",
+	}
+	req = mux.SetURLVars(req, vars)
+	writer := httptest.NewRecorder()
+
+	mockedDB.On("GetMessagesWithPagination", "test", int64(100), &models.Paginator{SodOffset: 100, NMessages: 20})
+
+	err := FetchMessages(mockedEnv, writer, req)
+	resp := writer.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
+	var messagePage models.MessagePage
+	json.Unmarshal(body, &messagePage)
+
+	mockedDB.AssertCalled(t, "GetMessagesWithPagination", "test", int64(100), &models.Paginator{SodOffset: 100, NMessages: 20})
+
+	assert.Nil(t, err)
+	assert.Equal(t, int64(20), messagePage.PageInfo.NMessages)
+	assert.Equal(t, int64(100), messagePage.PageInfo.SodOffset)
+	assert.Equal(t, uint64(12), messagePage.Messages[0].OrderID)
+}
+
+func TestFetchMessagesNegativeNMessages(t *testing.T) {
+	mockedDB := &mockDB{}
+	mockedEnv := &Env{mockedDB}
+	req := httptest.NewRequest("GET", "/messages/test/100?nMessages=-25", nil)
+	vars := map[string]string{
+		"instrument": "test",
+		"sodOffset":  "100",
+	}
+	req = mux.SetURLVars(req, vars)
+	writer := httptest.NewRecorder()
+
+	mockedDB.On("GetMessagesWithPagination", "test", int64(100), &models.Paginator{SodOffset: 100, NMessages: -25})
+
+	err := FetchMessages(mockedEnv, writer, req)
+	resp := writer.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
+	var messagePage models.MessagePage
+	json.Unmarshal(body, &messagePage)
+
+	mockedDB.AssertCalled(t, "GetMessagesWithPagination", "test", int64(100), &models.Paginator{SodOffset: 100, NMessages: -25})
+
+	assert.Nil(t, err)
+	assert.Equal(t, int64(-25), messagePage.PageInfo.NMessages)
+	assert.Equal(t, int64(100), messagePage.PageInfo.SodOffset)
+	assert.Equal(t, 2, len(messagePage.Messages))
+	// Checking to see if slice is reversed
+	assert.Equal(t, uint64(13), messagePage.Messages[0].OrderID)
+	assert.Equal(t, uint64(12), messagePage.Messages[1].OrderID)
+}
+
+func TestFetchMessagesBadInput(t *testing.T) {
+	mockedDB := &mockDB{}
+	mockedEnv := &Env{mockedDB}
+	req := httptest.NewRequest("GET", "/messages/test/10aa0", nil)
+	vars := map[string]string{
+		"instrument": "test",
+		"sodOffset":  "10aa0",
+	}
+	req = mux.SetURLVars(req, vars)
+	writer := httptest.NewRecorder()
+
+	mockedDB.On("GetMessagesWithPagination", "test", mock.Anything, mock.Anything, mock.Anything)
+
+	err := FetchMessages(mockedEnv, writer, req)
+
+	mockedDB.AssertNotCalled(t, "GetMessagesWithPagination", mock.Anything, mock.Anything, mock.Anything)
+	assert.NotNil(t, err)
+}

--- a/core/graphelier-service/api/hndlrs/obhandler.go
+++ b/core/graphelier-service/api/hndlrs/obhandler.go
@@ -49,6 +49,5 @@ func JSONOrderbook(env *Env, w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-
 	return nil
 }

--- a/core/graphelier-service/api/routes.go
+++ b/core/graphelier-service/api/routes.go
@@ -40,4 +40,10 @@ var routes = Routes{
 		"/orderbook/{instrument}/{timestamp}",
 		hndlrs.CustomHandler{H: hndlrs.JSONOrderbook},
 	},
+	Route{
+		"Message",
+		"GET",
+		"/messages/{instrument}/{sodOffset}",
+		hndlrs.CustomHandler{H: hndlrs.FetchMessages},
+	},
 }

--- a/core/graphelier-service/models/messages.go
+++ b/core/graphelier-service/models/messages.go
@@ -23,3 +23,9 @@ const (
 	Execute  MessageType = 4
 	Ignore   MessageType = 5
 )
+
+// MessagePage is a list of messages along with pagination information
+type MessagePage struct {
+	PageInfo Paginator  `json:"pageInfo"`
+	Messages []*Message `json:"messages"`
+}

--- a/core/graphelier-service/models/paginator.go
+++ b/core/graphelier-service/models/paginator.go
@@ -1,0 +1,7 @@
+package models
+
+// Paginator contains info about the page of data being requested
+type Paginator struct {
+	NMessages int64 `json:"nMessages"`
+	SodOffset int64 `json:"sod_offset"`
+}


### PR DESCRIPTION
- Backend now serves messages using sod_offset field
- Connector was changed to be an interface to allow for testing
- Handler now writes header before encoding json object because
it was giving warnings before