### PR TITLE
[#81] Adjust price on extended samples

### DIFF
--- a/core/scripts/lobster/extender.py
+++ b/core/scripts/lobster/extender.py
@@ -210,6 +210,5 @@ class Extender:
                 continue
 
             # Delete all possible conflicts from the book first
-            if m.message_type == MessageType.NEW_ORDER:
-                yield from self.handle_conflicts(ob_ref.conflicts(m), m)
+            yield from self.handle_conflicts(ob_ref.conflicts(m), m)
             yield from self._yield_n_copies(m)

--- a/core/scripts/lobster/extender.py
+++ b/core/scripts/lobster/extender.py
@@ -4,11 +4,24 @@ import random
 from collections import defaultdict, namedtuple
 from datetime import datetime, time, timedelta
 
+from models.order_book import OrderBook
 from models.message import Message, MessageType
 from lobster.parser import LobsterMessageParser
 
 
 Placement = namedtuple('Placement', ['index', 'message'])
+
+
+class _TopOfBook:
+    def __init__(self, ask, bid):
+        self.ask = ask
+        self.bid = bid
+
+    def get(self, direction):
+        return self.ask if direction == -1 else self.bid
+
+    def __sub__(self, o):
+        return _TopOfBook(self.ask - o.ask, self.bid - o.bid)
 
 
 def _endless_copies(l):
@@ -92,6 +105,7 @@ def _backfill(initial_messages, n_duplicates):
 
     id_diff = max(id_map) - min(id_map) + 1
     backfilled = []
+    upper_delete_bound = int(len(initial_messages) / 10)
     for id_, placements in id_map.items():
         first_place = placements[0]
         if first_place.message.message_type != MessageType.NEW_ORDER:
@@ -112,7 +126,7 @@ def _backfill(initial_messages, n_duplicates):
         unfilled_qty = _unfilled_qty_for_messages(placements)
         if unfilled_qty:
             # Unfilled order
-            new_index = _rand_range(0, first_place.index)
+            new_index = _rand_range(0, upper_delete_bound)
             time_diff = initial_messages[new_index].time - \
                 initial_messages[max(0, new_index - 1)].time
             _time = initial_messages[new_index].time + \
@@ -123,7 +137,8 @@ def _backfill(initial_messages, n_duplicates):
                     new_index,
                     Message(_time, MessageType.DELETE,
                             id_ - id_diff * n_duplicates, unfilled_qty,
-                            first_place.message.price, first_place.message.direction)
+                            first_place.message.price, first_place.message.direction,
+                            fake=True)
                 )
             )
 
@@ -132,8 +147,9 @@ def _backfill(initial_messages, n_duplicates):
 
 class Extender:
 
-    def __init__(self, file, start_time: float, n_duplicates: int):
+    def __init__(self, file, start_time: float, n_duplicates: int, initial_top_of_book):
         self.n_duplicates = n_duplicates
+        self.initial_top_of_book = _TopOfBook(*initial_top_of_book)
         print('Parsing sample set of messages...')
         message_parser = LobsterMessageParser(start_time)
         self.initial_messages = [
@@ -145,7 +161,8 @@ class Extender:
             self.initial_messages[0].time
 
         print('Backfilling for missing messages in sample...')
-        backfilled, self.id_diff = _backfill(self.initial_messages, n_duplicates)
+        backfilled, self.id_diff = _backfill(
+            self.initial_messages, n_duplicates)
         self.mixed_messages = sorted(_mix_by_index(self.initial_messages, backfilled),
                                      key=lambda x: x.time)
         print('Added {} messages to fill holes in sample.\n'.format(len(backfilled)))
@@ -159,15 +176,40 @@ class Extender:
                 m_copy.id += i * self.id_diff
             yield m_copy
 
-    def extend_sample(self, day_diff: int):
+    def handle_conflicts(self, conflicts, msg):
+        return [
+            Message(msg.time, MessageType.DELETE, order.id, order.qty,
+                    order.price, order.direction)
+            for order in conflicts
+        ]
+
+    def extend_sample(self, day_diff: int, ob_ref: OrderBook):
         for m in self.initial_messages:
             m_ = m.copy()
             m_.time += day_diff
             yield from self._yield_n_copies(m_)
 
+        prev_loop = 0
+        prev_diff = None
+        diff_top_of_book = _TopOfBook(0, 0)
         for loop_count, m in _endless_copies(self.mixed_messages):
+            if loop_count > prev_loop:
+                prev_loop = loop_count
+                prev_diff = diff_top_of_book
+                diff_top_of_book = _TopOfBook(ob_ref.ask, ob_ref.bid) - \
+                    self.initial_top_of_book
             m.time += day_diff + self.time_diff * loop_count
             if m.id != 0:
                 m.id += self.id_diff * loop_count * self.n_duplicates
 
+            m.price = m.price + \
+                (prev_diff if m.fake else diff_top_of_book).get(m.direction)
+
+            if m.fake and not ob_ref.has_order(m):
+                # Deleted through handle conflict
+                continue
+
+            # Delete all possible conflicts from the book first
+            if m.message_type == MessageType.NEW_ORDER:
+                yield from self.handle_conflicts(ob_ref.conflicts(m), m)
             yield from self._yield_n_copies(m)

--- a/core/scripts/lobster/parser.py
+++ b/core/scripts/lobster/parser.py
@@ -24,9 +24,9 @@ class LobsterMessageParser:
             # This maps indexes to object keys and the corresponding function to parse it from a string
             ('time', lambda x: float(x) * 10**9 + start_timestamp),
             ('message_type', lambda x: _lobster_msg_types.get(x, MessageType.IGNORE)),
-            ('id_', int),
+            ('id', int),
             ('share_quantity', int),
-            ('price', lambda x: float(x) / 10000),
+            ('price', int),
             ('direction', int)
         )
 
@@ -34,3 +34,12 @@ class LobsterMessageParser:
         kwargs = {key: parse_fun(
             line[index]) for index, (key, parse_fun) in enumerate(self.line_parsers)}
         return Message(**kwargs)
+
+
+def parse_top_of_book(ob_file_path: str) -> Tuple[int, int]:
+    line = ''
+    with open(ob_file_path, 'r') as f:
+        line = f.readline()
+
+    values = line.split(',')
+    return int(values[0]), int(values[2])

--- a/core/scripts/models/message.py
+++ b/core/scripts/models/message.py
@@ -11,20 +11,23 @@ class MessageType(enum.IntEnum):
 
 
 class Message:
-    def __init__(self, time, message_type, id_, share_quantity, price, direction):
+    def __init__(self, time, message_type, id, share_quantity, price, direction, sod_offset=0, fake=False):
         self.time = time
         self.message_type = message_type
-        self.id = id_
+        self.id = id
         self.share_quantity = share_quantity
         self.price = price
         self.direction = direction
-        self.sod_offset = 0
+        self.sod_offset = sod_offset
+        self.fake = fake
 
     def __str__(self):
         return ('<Message id="{id}" time="{timef}" type="{message_type}" ' +
-                'price="{price}" qty="{share_quantity}" direction="{direction}">').format(
-                    **self.__dict__, timef=datetime.fromtimestamp(
-                        self.time // 10**9).strftime('%Y-%m-%d %H:%M:%S'))
+                'price="{pricef}" qty="{share_quantity}" direction="{direction}">').format(
+                    **self.__dict__,
+                    timef=datetime.fromtimestamp(
+                        self.time // 10**9).strftime('%Y-%m-%d %H:%M:%S'),
+                    pricef=self.price / 10000)
 
     def copy(self):
-        return Message(self.time, self.message_type, self.id, self.share_quantity, self.price, self.direction)
+        return Message(**self.__dict__)

--- a/core/scripts/models/order_book.py
+++ b/core/scripts/models/order_book.py
@@ -19,9 +19,9 @@ class Order:
 class OrderBook:
     def __init__(self, instrument):
         self.instrument = instrument
-        self.bid_book: Dict[float, List[Order]] = defaultdict(list)
-        self.ask_book: Dict[float, List[Order]] = defaultdict(list)
-        self.bid = 0.0
+        self.bid_book: Dict[int, List[Order]] = defaultdict(list)
+        self.ask_book: Dict[int, List[Order]] = defaultdict(list)
+        self.bid = 0
         self.ask = float('inf')
         self.id_map: Dict[int, Order] = {}
         self.last_time = 0
@@ -101,12 +101,34 @@ class OrderBook:
         self.last_time = msg.time
         self.last_sod_offset = msg.sod_offset
 
+    def conflicts(self, msg: Message):
+        ret = []
+        if msg.direction == -1:
+            if msg.price <= self.bid:
+                for price in sorted(self.bid_book, reverse=True):
+                    if price < msg.price:
+                        break
+                    ret += self.bid_book[price]
+        elif msg.direction == 1:
+            if msg.price >= self.ask:
+                for price in sorted(self.ask_book):
+                    if price > msg.price:
+                        break
+                    ret += self.ask_book[price]
+        return ret
+
+    def has_order(self, msg: Message):
+        return (msg.direction == -1 and
+                msg.price in self.ask_book and msg in self.ask_book[msg.price]) \
+            or (msg.direction == 1 and
+                msg.price in self.bid_book and msg in self.bid_book[msg.price])
+
     def __str__(self):
         return '<OrderBook bids={bids} asks={asks} time="{time}">'.format(
-            bids='(count={}, best={})'.format(sum(len(l)
-                                                  for l in self.bid_book.values()), self.bid),
-            asks='(count={}, best={})'.format(sum(len(l)
-                                                  for l in self.ask_book.values()), self.ask),
+            bids='(count={}, best={})'.format(sum(len(l) for l
+                                                  in self.bid_book.values()), self.bid / 10000),
+            asks='(count={}, best={})'.format(sum(len(l) for l
+                                                  in self.ask_book.values()), self.ask / 10000),
             time=datetime.fromtimestamp(
                 self.last_time // 10**9).strftime('%Y-%m-%d %H:%M:%S')
         )

--- a/core/scripts/models/order_book.py
+++ b/core/scripts/models/order_book.py
@@ -101,8 +101,17 @@ class OrderBook:
         self.last_time = msg.time
         self.last_sod_offset = msg.sod_offset
 
-    def conflicts(self, msg: Message):
+    def conflicts(self, msg: Message) -> List[Order]:
+        """Returns all orders which would conflict with the given message.
+        Only NEW_ORDER messages can cause a conflict by altering the top-of-book.
+
+        In the case of a new ask, return all existing bids with a higher price.
+        In the case of a new bid, return all existing asks with a lower price.
+        """
         ret = []
+        if msg.message_type != MessageType.NEW_ORDER:
+            return ret
+
         if msg.direction == -1:
             if msg.price <= self.bid:
                 for price in sorted(self.bid_book, reverse=True):

--- a/core/scripts/mongo_db/db_utils.py
+++ b/core/scripts/mongo_db/db_utils.py
@@ -5,11 +5,11 @@ def order_book_to_dict(order_book):
     return {
         "instrument": order_book.instrument,
         "bids": [{
-            "price": price,
+            "price": price / 10000,
             "orders": [order_to_dict(order) for order in orders]
         } for price, orders in sorted(order_book.bid_book.items(), reverse=True)],
         "asks": [{
-            "price": price,
+            "price": price / 10000,
             "orders": [order_to_dict(order) for order in orders]
         } for price, orders in sorted(order_book.ask_book.items())],
         "timestamp": _round_up(order_book.last_time, 9),
@@ -31,7 +31,7 @@ def message_to_dict(message, instrument):
         "message_type": int(message.message_type),
         "order_id": message.id,
         "share_quantity": message.share_quantity,
-        "price": message.price,
+        "price": message.price / 10000,
         "direction": message.direction,
         "sod_offset": message.sod_offset
     }

--- a/core/scripts/pylintrc
+++ b/core/scripts/pylintrc
@@ -2,4 +2,4 @@
 
 # Only keep warnings and errors, disable refactor and convention levels
 # Also disable a few classes we don't mind
-disable=R,C,fixme
+disable=R,C,fixme,redefined-builtin

--- a/core/scripts/tests/test_extender.py
+++ b/core/scripts/tests/test_extender.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from datetime import datetime
 
 from models.message import Message, MessageType
+from models.order_book import OrderBook
 from lobster.extender import (
     weekdays, Placement, Extender,
     _initial_qty_for_messages, _mix_by_index, _unfilled_qty_for_messages
@@ -79,18 +80,20 @@ class ExtenderTest(unittest.TestCase):
         sample = []
         extended = []
         with open('tests/messages_sample.fixture', 'r') as f:
-            e = Extender(f, start, 1)
+            e = Extender(f, start, 1, (1356500, 1356300))
 
             sample_count = 9
             extended_count = (9 + 7) * 2
 
-            for m in e.extend_sample(0):
+            ob = OrderBook("SPY")
+            for m in e.extend_sample(0, ob):
                 if len(sample) < sample_count:
                     sample.append(m)
                 elif len(extended) < extended_count:
                     extended.append(m)
                 else:
                     break
+                ob.send(m)
 
         new_orders = [m for m in extended
                       if m.message_type == MessageType.NEW_ORDER]

--- a/core/scripts/tests/test_orderbook.py
+++ b/core/scripts/tests/test_orderbook.py
@@ -71,13 +71,17 @@ class TestOrderbook(unittest.TestCase):
 
         orderbook.send(new_order)
         orderbook.send(new_order_2)
-        bids = list(orderbook.conflicts(Message(3, MessageType.DELETE, 13, 10, 1, -1)))
-        asks = list(orderbook.conflicts(Message(3, MessageType.DELETE, 13, 10, 2, 1)))
+        bids = list(orderbook.conflicts(
+            Message(3, MessageType.NEW_ORDER, 13, 10, 1, -1)))
+        asks = list(orderbook.conflicts(
+            Message(3, MessageType.NEW_ORDER, 13, 10, 2, 1)))
         self.assertListEqual(bids, [Order(12, 10, 1, 1)])
         self.assertListEqual(asks, [Order(11, 10, 2, -1)])
 
-        empty_bids = list(orderbook.conflicts(Message(3, MessageType.DELETE, 13, 10, 1, 1)))
-        empty_asks = list(orderbook.conflicts(Message(3, MessageType.DELETE, 13, 10, 2, -1)))
+        empty_bids = list(orderbook.conflicts(
+            Message(3, MessageType.DELETE, 13, 10, 1, 1)))
+        empty_asks = list(orderbook.conflicts(
+            Message(3, MessageType.DELETE, 13, 10, 2, -1)))
         self.assertListEqual(empty_bids, [])
         self.assertListEqual(empty_asks, [])
 
@@ -86,7 +90,11 @@ class TestOrderbook(unittest.TestCase):
         orderbook.send(Message(1, MessageType.NEW_ORDER, 11, 10, 2, -1))
         orderbook.send(Message(2, MessageType.NEW_ORDER, 12, 10, 1, 1))
 
-        self.assertTrue(orderbook.has_order(Message(3, MessageType.DELETE, 11, 10, 2, -1)))
-        self.assertFalse(orderbook.has_order(Message(3, MessageType.DELETE, 11, 10, 2, 1)))
-        self.assertFalse(orderbook.has_order(Message(3, MessageType.DELETE, 12, 10, 2, 1)))
-        self.assertTrue(orderbook.has_order(Message(3, MessageType.DELETE, 12, 10, 1, 1)))
+        self.assertTrue(orderbook.has_order(
+            Message(3, MessageType.DELETE, 11, 10, 2, -1)))
+        self.assertFalse(orderbook.has_order(
+            Message(3, MessageType.DELETE, 11, 10, 2, 1)))
+        self.assertFalse(orderbook.has_order(
+            Message(3, MessageType.DELETE, 12, 10, 2, 1)))
+        self.assertTrue(orderbook.has_order(
+            Message(3, MessageType.DELETE, 12, 10, 1, 1)))


### PR DESCRIPTION
- If message would lead to a price movement, drop all orders that would conflict with it first
- Prices are changed according to the top of book before the extended sample is started
- Added dependency on the `orderbook` file from Lobster, data can also be passed through the new `--top-of-book` argument to avoid downloading the file