### PR TITLE
[#95] Converted timestamp to int to keep precision

### DIFF
--- a/core/scripts/importer.py
+++ b/core/scripts/importer.py
@@ -27,7 +27,7 @@ EOD = 16 * 60 * 60 * 10**9  # 4:00 PM as ns
 
 
 def load(message_file, ob_file_path, start_time, instrument, extend, top_of_book):
-    start_timestamp = start_time.timestamp() * 10**9  # in nanoseconds
+    start_timestamp = int(start_time.timestamp() * 10**9)  # in nanoseconds
     interval = 10 * 10**9  # in nanoseconds
 
     initial_top_of_book = (int(top_of_book[0]), int(top_of_book[1])) \
@@ -37,8 +37,8 @@ def load(message_file, ob_file_path, start_time, instrument, extend, top_of_book
     for day in weekdays(start_timestamp, int(extend[0])):
         order_book = OrderBook(instrument)
         order_book.last_time = day
-        # day is a float, need to convert it to avoid floating point error
-        order_book.last_sod_offset = sod_offset_counter = int(day)
+
+        order_book.last_sod_offset = sod_offset_counter = day
         last_multiple = 1
         message_buffer = []
 

--- a/core/scripts/lobster/extender.py
+++ b/core/scripts/lobster/extender.py
@@ -1,13 +1,11 @@
 import csv
 import random
-
 from collections import defaultdict, namedtuple
 from datetime import datetime, time, timedelta
 
-from models.order_book import OrderBook
-from models.message import Message, MessageType
 from lobster.parser import LobsterMessageParser
-
+from models.message import Message, MessageType
+from models.order_book import OrderBook
 
 Placement = namedtuple('Placement', ['index', 'message'])
 
@@ -48,10 +46,10 @@ def _mix_by_index(base, mix):
         yield b
 
 
-def weekdays(start: float, n):
+def weekdays(start: int, n):
     current = datetime.fromtimestamp(start / 10 ** 9).date()
     for _ in range(n):
-        yield datetime.combine(current, time()).timestamp() * 10 ** 9
+        yield int(datetime.combine(current, time()).timestamp() * 10 ** 9)
         offset = 3 if current.weekday() == 4 else 1
         current = current + timedelta(days=offset)
 
@@ -147,7 +145,7 @@ def _backfill(initial_messages, n_duplicates):
 
 class Extender:
 
-    def __init__(self, file, start_time: float, n_duplicates: int, initial_top_of_book):
+    def __init__(self, file, start_time: int, n_duplicates: int, initial_top_of_book):
         self.n_duplicates = n_duplicates
         self.initial_top_of_book = _TopOfBook(*initial_top_of_book)
         print('Parsing sample set of messages...')
@@ -157,8 +155,8 @@ class Extender:
         print('Found {} messages in sample.\n'.format(
             len(self.initial_messages)))
 
-        self.time_diff = self.initial_messages[-1].time - \
-            self.initial_messages[0].time
+        self.time_diff = int(self.initial_messages[-1].time -
+                             self.initial_messages[0].time)
 
         print('Backfilling for missing messages in sample...')
         backfilled, self.id_diff = _backfill(

--- a/core/scripts/lobster/parser.py
+++ b/core/scripts/lobster/parser.py
@@ -18,11 +18,11 @@ class LobsterMessageParser:
     See LOBSTER_SampleFiles_ReadMe.txt for official documentation
     """
 
-    def __init__(self, start_timestamp: float):
+    def __init__(self, start_timestamp: int):
         self.line_parsers: Tuple[str, Callable] = (
             # Each index corresponds to an index in the line.
             # This maps indexes to object keys and the corresponding function to parse it from a string
-            ('time', lambda x: float(x) * 10**9 + start_timestamp),
+            ('time', lambda x: int(float(x) * 10**9) + start_timestamp),
             ('message_type', lambda x: _lobster_msg_types.get(x, MessageType.IGNORE)),
             ('id', int),
             ('share_quantity', int),


### PR DESCRIPTION
- Importer previously lost precision when storing to the db because it
was storing floats for the timestamp field. Now it will store ints.