### PR TITLE
[#113] Instruments route

### DIFF
--- a/core/graphelier-service/api/hndlrs/insthandler.go
+++ b/core/graphelier-service/api/hndlrs/insthandler.go
@@ -1,0 +1,21 @@
+package hndlrs
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// FetchInstruments : Retrieve available instruments
+func FetchInstruments(env *Env, w http.ResponseWriter, r *http.Request) error {
+	instruments, err := env.Connector.GetInstruments()
+	if err != nil {
+		return StatusError{500, err}
+	}
+
+	err = json.NewEncoder(w).Encode(instruments)
+	if err != nil {
+		return StatusError{500, err}
+	}
+
+	return nil
+}

--- a/core/graphelier-service/api/hndlrs/insthandler_test.go
+++ b/core/graphelier-service/api/hndlrs/insthandler_test.go
@@ -1,0 +1,58 @@
+package hndlrs
+
+import (
+	"encoding/json"
+	"graphelier/core/graphelier-service/models"
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockDBIHndlr struct {
+	mock.Mock
+}
+
+func (db *mockDBIHndlr) GetInstruments() (result []string, err error) {
+	result = []string{"TEST", "SPY", "AAPL"}
+	return
+}
+
+func (db *mockDBIHndlr) GetSingleMessage(instrument string, sodOffset int64) (result *models.Message, err error) {
+	return
+}
+
+func (db *mockDBIHndlr) GetOrderbook(instrument string, timestamp uint64) (result *models.Orderbook, err error) {
+	return
+}
+
+func (db *mockDBIHndlr) GetMessagesByTimestamp(instrument string, timestamp uint64) (results []*models.Message, err error) {
+	return
+}
+
+func (db *mockDBIHndlr) GetMessagesWithPagination(instrument string, paginator *models.Paginator) (result []*models.Message, err error) {
+	return
+}
+
+func TestFetchInstruments(t *testing.T) {
+	mockedDB := &mockDBIHndlr{}
+	mockedEnv := &Env{mockedDB}
+
+	req := httptest.NewRequest("GET", "/instruments/", nil)
+	writer := httptest.NewRecorder()
+
+	mockedDB.On("GetInstruments")
+
+	err := FetchInstruments(mockedEnv, writer, req)
+	assert.Nil(t, err)
+
+	resp := writer.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
+	var instruments []string
+	err = json.Unmarshal(body, &instruments)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 3, len(instruments))
+}

--- a/core/graphelier-service/api/hndlrs/msghandler_test.go
+++ b/core/graphelier-service/api/hndlrs/msghandler_test.go
@@ -18,6 +18,10 @@ type mockDBMsgHndlr struct {
 	mock.Mock
 }
 
+func (db *mockDBMsgHndlr) GetInstruments() (result []string, err error) {
+	return
+}
+
 func (db *mockDBMsgHndlr) GetSingleMessage(instrument string, sodOffset int64) (result *models.Message, err error) {
 	return &models.Message{}, nil
 }

--- a/core/graphelier-service/api/hndlrs/obhandler_test.go
+++ b/core/graphelier-service/api/hndlrs/obhandler_test.go
@@ -17,6 +17,10 @@ type mockDBObHndlr struct {
 	mock.Mock
 }
 
+func (db *mockDBObHndlr) GetInstruments() (result []string, err error) {
+	return
+}
+
 func (db *mockDBObHndlr) GetSingleMessage(instrument string, sodOffset int64) (result *models.Message, err error) {
 	db.Called(instrument, sodOffset)
 	return &models.Message{Direction: -1, Instrument: "test", Type: 1, OrderID: 15, Price: 100, ShareQuantity: 10, Timestamp: 100, SodOffset: 1}, nil

--- a/core/graphelier-service/api/routes.go
+++ b/core/graphelier-service/api/routes.go
@@ -52,4 +52,10 @@ var routes = Routes{
 		"/messages/{instrument}/{sodOffset}",
 		hndlrs.CustomHandler{H: hndlrs.FetchMessages},
 	},
+	Route{
+		"Instruments",
+		"GET",
+		"/instruments/",
+		hndlrs.CustomHandler{H: hndlrs.FetchInstruments},
+	},
 }

--- a/core/graphelier-service/db/mongo.go
+++ b/core/graphelier-service/db/mongo.go
@@ -18,6 +18,7 @@ type Datastore interface {
 	GetMessagesByTimestamp(instrument string, timestamp uint64) ([]*models.Message, error)
 	GetMessagesWithPagination(instrument string, paginator *models.Paginator) ([]*models.Message, error)
 	GetSingleMessage(instrument string, sodOffset int64) (*models.Message, error)
+	GetInstruments() ([]string, error)
 }
 
 // Connector : A struct that represents the database
@@ -160,6 +161,23 @@ func (c *Connector) GetSingleMessage(instrument string, sodOffset int64) (result
 	err = collection.FindOne(context.TODO(), filter, options).Decode(&result)
 	if err != nil {
 		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetInstruments : Returns available instruments
+func (c *Connector) GetInstruments() (result []string, err error) {
+	collection := c.Database("graphelier-db").Collection("orderbooks")
+	filter := bson.D{} // No filter
+
+	res, err := collection.Distinct(context.TODO(), "instrument", filter, options.Distinct())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range res {
+		result = append(result, r.(string))
 	}
 
 	return result, nil


### PR DESCRIPTION
Serve available instruments to let app know which values are valid

Route spec:
    path: `/instruments/`
    response format: `["SPY","AAPL","MSFT"]`, a json list of strings