### PR TITLE
[#94, #128] Store interval value in meta collection

### DIFF
--- a/core/graphelier-service/api/hndlrs/insthandler_test.go
+++ b/core/graphelier-service/api/hndlrs/insthandler_test.go
@@ -36,6 +36,10 @@ func (db *mockDBIHndlr) GetMessagesWithPagination(instrument string, paginator *
 	return
 }
 
+func (db *mockDBIHndlr) RefreshCache() (err error) {
+	return
+}
+
 func TestFetchInstruments(t *testing.T) {
 	mockedDB := &mockDBIHndlr{}
 	mockedEnv := &Env{mockedDB}

--- a/core/graphelier-service/api/hndlrs/msghandler_test.go
+++ b/core/graphelier-service/api/hndlrs/msghandler_test.go
@@ -39,6 +39,9 @@ func (db *mockDBMsgHndlr) GetMessagesWithPagination(instrument string, paginator
 	messages = append(messages, &models.Message{Direction: -1, Instrument: "test", Type: 1, OrderID: 13, Price: 100, ShareQuantity: 10, Timestamp: 100, SodOffset: 2})
 	return messages, nil
 }
+func (db *mockDBMsgHndlr) RefreshCache() (err error) {
+	return
+}
 
 func TestFetchMessagesSuccess(t *testing.T) {
 	mockedDB := &mockDBMsgHndlr{}

--- a/core/graphelier-service/api/hndlrs/obhandler.go
+++ b/core/graphelier-service/api/hndlrs/obhandler.go
@@ -128,6 +128,5 @@ func RefreshCache(env *Env, w http.ResponseWriter, r *http.Request) error {
 		return StatusError{500, err}
 	}
 
-	w.WriteHeader(http.StatusOK)
 	return nil
 }

--- a/core/graphelier-service/api/hndlrs/obhandler.go
+++ b/core/graphelier-service/api/hndlrs/obhandler.go
@@ -2,6 +2,7 @@ package hndlrs
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -34,7 +35,6 @@ func FetchOrderbook(env *Env, w http.ResponseWriter, r *http.Request) error {
 	}
 	orderbook.ApplyMessagesToOrderbook(messages)
 
-	w.WriteHeader(http.StatusOK)
 	err = json.NewEncoder(w).Encode(orderbook)
 	if err != nil {
 		return StatusError{500, err}
@@ -75,7 +75,7 @@ func FetchOrderbookDelta(env *Env, w http.ResponseWriter, r *http.Request) (err 
 
 	// get previous book for high number of backward messages
 	for totalOffset < 0 {
-		prevSnapTime := int64(orderbook.Timestamp - 10000000000)
+		prevSnapTime := int64(orderbook.Timestamp - 1)
 		if prevSnapTime < 0 {
 			return StatusError{400, err}
 		}
@@ -112,5 +112,22 @@ func FetchOrderbookDelta(env *Env, w http.ResponseWriter, r *http.Request) (err 
 		return StatusError{500, err}
 	}
 
+	return nil
+}
+
+// RefreshCache : Updates the db connector's cache to reflect database state changes
+func RefreshCache(env *Env, w http.ResponseWriter, r *http.Request) error {
+	err := env.Connector.RefreshCache()
+	if err != nil {
+		return StatusError{500, err}
+	}
+
+	log.Println("Cache refreshed.")
+	err = json.NewEncoder(w).Encode(make(map[string]string))
+	if err != nil {
+		return StatusError{500, err}
+	}
+
+	w.WriteHeader(http.StatusOK)
 	return nil
 }

--- a/core/graphelier-service/api/hndlrs/obhandler_test.go
+++ b/core/graphelier-service/api/hndlrs/obhandler_test.go
@@ -41,6 +41,9 @@ func (db *mockDBObHndlr) GetMessagesWithPagination(instrument string, paginator 
 	messages = append(messages, &models.Message{Direction: -1, Instrument: "test", Type: 1, OrderID: 15, Price: 100, ShareQuantity: 10, Timestamp: 100, SodOffset: 3})
 	return messages, nil
 }
+func (db *mockDBObHndlr) RefreshCache() (err error) {
+	return
+}
 
 func TestFetchOrderbookDeltaSuccess(t *testing.T) {
 	mockedDB := &mockDBObHndlr{}

--- a/core/graphelier-service/api/routes.go
+++ b/core/graphelier-service/api/routes.go
@@ -58,4 +58,10 @@ var routes = Routes{
 		"/instruments/",
 		hndlrs.CustomHandler{H: hndlrs.FetchInstruments},
 	},
+	Route{
+		"RefreshCache",
+		"GET",
+		"/_refresh/",
+		hndlrs.CustomHandler{H: hndlrs.RefreshCache},
+	},
 }

--- a/core/graphelier-service/api/routes.go
+++ b/core/graphelier-service/api/routes.go
@@ -61,7 +61,7 @@ var routes = Routes{
 	Route{
 		"RefreshCache",
 		"GET",
-		"/_refresh/",
+		"/_refresh_cache/",
 		hndlrs.CustomHandler{H: hndlrs.RefreshCache},
 	},
 }

--- a/core/graphelier-service/models/orderbooks.go
+++ b/core/graphelier-service/models/orderbooks.go
@@ -19,8 +19,8 @@ type Level struct {
 // Orderbook : A struct that represents the entire orderbook to send as json
 type Orderbook struct {
 	Instrument    string   `json:"instrument"`
-	Bids          []*Level `json:"bids,omitempty"`
-	Asks          []*Level `json:"asks,omitempty"`
+	Bids          []*Level `json:"bids"`
+	Asks          []*Level `json:"asks"`
 	Timestamp     uint64   `json:"timestamp,string"`
 	LastSodOffset uint64   `json:"last_sod_offset,string" bson:"last_sod_offset"`
 }

--- a/core/scripts/importer.py
+++ b/core/scripts/importer.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from lobster.extender import Extender, weekdays, TZ
 from lobster.parser import parse_top_of_book
 from models.order_book import OrderBook
-from mongo_db.db_connector import save_messages, save_order_book
+from mongo_db.db_connector import save_messages, save_order_book, check_interval
 
 parser = argparse.ArgumentParser(
     description='Import dataset into mongodb', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -14,11 +14,17 @@ parser.add_argument(
 parser.add_argument('start_time', help='Time at which sample starts, e.g. "2012-06-21 00:00:00"',
                     type=lambda x: datetime.strptime(x, '%Y-%m-%d %H:%M:%S'))
 parser.add_argument('instrument', help='Name of instrument for sample')
-parser.add_argument('-e', '--extend', nargs=2,
-                    help='Number of days to extend the sample over and the number of times to duplicate messages',
-                    default=[1, 1])
+parser.add_argument('-e', '--extend',
+                    help='Number of days to extend the sample over',
+                    default=1)
+parser.add_argument('-d', '--duplicate',
+                    help='Number of times to duplicate messages',
+                    default=1)
 parser.add_argument('-t', '--top-of-book', help='Top of book at the start of sample (ask, bid)',
                     nargs=2)
+parser.add_argument('-i', '--interval',
+                    help='Time in nanoseconds between orderbook snapshots',
+                    type=int, default=10**8)
 
 # Determines how many messages will be parsed before sending them to db
 MESSAGE_BATCH_SIZE = 200
@@ -26,57 +32,85 @@ MESSAGE_BATCH_SIZE = 200
 EOD = 16 * 60 * 60 * 10**9  # 4:00 PM as ns
 
 
-def load(message_file, ob_file_path, start_time, instrument, extend, top_of_book):
-    start_time = start_time.replace(tzinfo=TZ)
-    start_timestamp = int(start_time.timestamp() * 10**9)  # in nanoseconds
-    interval = 10 * 10**9  # in nanoseconds
+class _Loader:
+    def __init__(self, extender, start_timestamp, instrument, interval):
+        self.extender = extender
+        self.start_timestamp = start_timestamp
+        self.instrument = instrument
+        self.interval = interval
+        self.order_book = None
+        self.sod_offset_counter = 0
+        self.message_buffer = []
+        self.last_multiple = 0
 
-    initial_top_of_book = (int(top_of_book[0]), int(top_of_book[1])) \
-        if top_of_book else parse_top_of_book(ob_file_path)
-    extender = Extender(message_file, start_timestamp,
-                        int(extend[1]), initial_top_of_book)
-    for day in weekdays(start_timestamp, int(extend[0])):
-        order_book = OrderBook(instrument)
-        order_book.last_time = day
+    def _new_book(self, day):
+        self.order_book = OrderBook(self.instrument)
+        self.order_book.last_time = day
+        self.order_book.last_sod_offset = day
+        self.sod_offset_counter = day
 
-        order_book.last_sod_offset = sod_offset_counter = day
-        last_multiple = 1
-        message_buffer = []
+    def _save_buffer(self):
+        save_messages(self.message_buffer, self.instrument)
+        self.message_buffer.clear()
 
-        day_diff = day - start_timestamp
+    def _handle_message(self, message):
+        message.sod_offset = self.sod_offset_counter
+        current_multiple = message.time // self.interval
+        if current_multiple > self.last_multiple:
+            print(str(self.order_book))
+            self.last_multiple = current_multiple
+            save_order_book(self.order_book)
+        self.message_buffer.append(message)
+
+        if len(self.message_buffer) > MESSAGE_BATCH_SIZE:
+            self._save_buffer()
+
+        self.order_book.send(message)
+        self.sod_offset_counter += 1
+
+    def load_single_day(self, day):
+        self._new_book(day)
+
+        self.last_multiple = 1
+
+        day_diff = day - self.start_timestamp
         max_time = day + EOD
-        for message in extender.extend_sample(day_diff, order_book):
+        for message in self.extender.extend_sample(day_diff, self.order_book):
             if message.time > max_time:
                 break
-            message.sod_offset = sod_offset_counter
-            current_multiple = message.time // interval
-            if current_multiple > last_multiple:
-                print(str(order_book))
-                last_multiple = current_multiple
-                save_order_book(order_book)
-            message_buffer.append(message)
-
-            if len(message_buffer) > MESSAGE_BATCH_SIZE:
-                save_messages(message_buffer, instrument)
-                message_buffer = []
-
-            order_book.send(message)
-            sod_offset_counter += 1
+            self._handle_message(message)
 
         # Flushing out remaining messages in buffer
-        if len(message_buffer) > 0:
-            save_messages(message_buffer, instrument)
+        if len(self.message_buffer) > 0:
+            self._save_buffer()
 
-        eod_clear = OrderBook(instrument)
+        eod_clear = OrderBook(self.instrument)
         eod_clear.last_time = max_time
-        eod_clear.last_sod_offset = sod_offset_counter
+        eod_clear.last_sod_offset = self.sod_offset_counter
         # save an empty order_book at the end of the day
         save_order_book(eod_clear)
 
         print('best bid volume={}\tbest ask volume={}'.format(
-            sum(o.qty for o in order_book.bid_book[order_book.bid]),
-            sum(o.qty for o in order_book.ask_book[order_book.ask])
+            sum(o.qty for o in self.order_book.bid_book[self.order_book.bid]),
+            sum(o.qty for o in self.order_book.ask_book[self.order_book.ask])
         ))
+
+
+def load(**kwargs):
+    """Loads the given messages file into the database. """
+    start_time = kwargs['start_time'].replace(tzinfo=TZ)
+    start_timestamp = int(start_time.timestamp() * 10**9)  # in nanoseconds
+
+    instrument = kwargs['instrument']
+    interval = check_interval(kwargs['interval'], instrument)
+
+    initial_top_of_book = parse_top_of_book(
+        kwargs['ob_file_path'], kwargs['top_of_book'])
+    extender = Extender(kwargs['message_file'], start_timestamp,
+                        int(kwargs['duplicate']), initial_top_of_book)
+    loader = _Loader(extender, start_timestamp, instrument, interval)
+    for day in weekdays(start_timestamp, int(kwargs['extend'])):
+        loader.load_single_day(day)
 
 
 def main():
@@ -89,8 +123,7 @@ def main():
             ob_file_path = input(
                 'Please provide the path to the orderbook file: ')
 
-    load(args.message_file, ob_file_path, args.start_time,
-         args.instrument, args.extend, args.top_of_book)
+    load(**args.__dict__)
 
 
 if __name__ == '__main__':

--- a/core/scripts/lobster/parser.py
+++ b/core/scripts/lobster/parser.py
@@ -36,7 +36,10 @@ class LobsterMessageParser:
         return Message(**kwargs)
 
 
-def parse_top_of_book(ob_file_path: str) -> Tuple[int, int]:
+def parse_top_of_book(ob_file_path: str, top_of_book: Tuple[str, str]) -> Tuple[int, int]:
+    if top_of_book:
+        return (int(top_of_book[0]), int(top_of_book[1]))
+
     line = ''
     with open(ob_file_path, 'r') as f:
         line = f.readline()

--- a/core/scripts/mongo_db/db_connector.py
+++ b/core/scripts/mongo_db/db_connector.py
@@ -2,28 +2,42 @@ import pymongo
 
 from mongo_db.db_utils import message_to_dict, order_book_to_dict
 
-_db = pymongo.MongoClient("mongodb://127.0.0.1:27017/")
-_order_book_collection = _db["graphelier-db"]["orderbooks"]
-_message_collection = _db["graphelier-db"]["messages"]
-_meta_collection = _db["graphelier-db"]["meta"]
+_DB_CLIENT = pymongo.MongoClient("mongodb://127.0.0.1:27017/")
+_DB = {
+    'orderbooks': _DB_CLIENT["graphelier-db"]["orderbooks"],
+    'messages': _DB_CLIENT["graphelier-db"]["messages"],
+    'meta': _DB_CLIENT["graphelier-db"]["meta"]
+}
 
 
 def save_order_book(order_book):
+    """Save an order book snapshot"""
     order_book_dict = order_book_to_dict(order_book)
-    _order_book_collection.insert_one(order_book_dict)
+    _DB['orderbooks'].insert_one(order_book_dict)
+
+
+def upsert_order_book(order_book):
+    """Upsert an order book snapshot"""
+    ob_dict = order_book_to_dict(order_book)
+    _DB['orderbooks'].replace_one(
+        {k: v for k, v in ob_dict.items() if k in ('instrument', 'timestamp')},
+        ob_dict, upsert=True
+    )
 
 
 def save_messages(messages, instrument):
+    """Save a list of messages"""
     messages_dict = [message_to_dict(m, instrument) for m in messages]
-    _message_collection.insert_many(messages_dict)
+    _DB['messages'].insert_many(messages_dict)
 
 
 def check_interval(interval, instrument):
-    exists = _meta_collection.find_one(
+    """Fetch or add the snapshot interval value for a given instrument"""
+    exists = _DB['meta'].find_one(
         {"instrument": instrument}, {"interval": 1, "_id": 0})
     if exists:
         return exists["interval"]
 
-    _meta_collection.insert_one(
+    _DB['meta'].insert_one(
         {"interval": interval, "instrument": instrument})
     return interval

--- a/core/scripts/mongo_db/db_connector.py
+++ b/core/scripts/mongo_db/db_connector.py
@@ -5,6 +5,7 @@ from mongo_db.db_utils import message_to_dict, order_book_to_dict
 _db = pymongo.MongoClient("mongodb://127.0.0.1:27017/")
 _order_book_collection = _db["graphelier-db"]["orderbooks"]
 _message_collection = _db["graphelier-db"]["messages"]
+_meta_collection = _db["graphelier-db"]["meta"]
 
 
 def save_order_book(order_book):
@@ -15,3 +16,14 @@ def save_order_book(order_book):
 def save_messages(messages, instrument):
     messages_dict = [message_to_dict(m, instrument) for m in messages]
     _message_collection.insert_many(messages_dict)
+
+
+def check_interval(interval, instrument):
+    exists = _meta_collection.find_one(
+        {"instrument": instrument}, {"interval": 1, "_id": 0})
+    if exists:
+        return exists["interval"]
+
+    _meta_collection.insert_one(
+        {"interval": interval, "instrument": instrument})
+    return interval


### PR DESCRIPTION
- Importer script maintains value per instrument
- Service reads and caches meta values on startup
	- This can also be refreshed by a GET to `/_refresh/`
- Default interval value in the script has been reduced to 0.1s from 10s
- Unified response format for `/orderbook/`, timestamps out of bounds return an empty orderbook

To allow migration of existing dataset, simply:
```
db.createCollection("meta")
db.meta.insertOne({instrument: "SPY", interval: NumberLong("10000000000")})
db.orderbook.insertOne({instrument: "SPY", bids: [], asks: [], timestamp: NumberLong("0"), last_sod_offset: NumberLong("0")})
```