### PR TITLE
[#146] Fixed crash on earliest time being selected

### DIFF
--- a/app/src/components/MultiDirectionalScroll.tsx
+++ b/app/src/components/MultiDirectionalScroll.tsx
@@ -66,7 +66,7 @@ class MultiDirectionalScroll extends Component<Props> {
         } = this.scroller;
         const { onReachTop, onReachBottom, children } = this.props;
 
-        if (children) {
+        if (children && firstChild && lastChild) {
             const topEdge = firstChild.offsetTop;
             const bottomEdge = lastChild.offsetTop + lastChild.offsetHeight;
             const scrolledUp = scrollTop + offsetTop;


### PR DESCRIPTION
Fixed for all usages of `MultiDirectionalScroll`.