### PR TITLE
[#134] Verbose logging with log levels for service

### DIFF
--- a/core/graphelier-service/api/hndlrs/handlers.go
+++ b/core/graphelier-service/api/hndlrs/handlers.go
@@ -44,7 +44,7 @@ type CustomHandler struct {
 
 // ServeHTTP : A function that links CustomHandler with http.Handler
 func (h CustomHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	defer utils.Timer(r.URL)()
+	defer utils.Timer(r.URL.String())()
 
 	err := h.H(h.E, w, r)
 

--- a/core/graphelier-service/api/hndlrs/handlers.go
+++ b/core/graphelier-service/api/hndlrs/handlers.go
@@ -1,10 +1,12 @@
 package hndlrs
 
 import (
-	"log"
 	"net/http"
 
+	log "github.com/sirupsen/logrus"
+
 	"graphelier/core/graphelier-service/db"
+	"graphelier/core/graphelier-service/utils"
 )
 
 // Error : An interface that represents a handler error
@@ -42,14 +44,17 @@ type CustomHandler struct {
 
 // ServeHTTP : A function that links CustomHandler with http.Handler
 func (h CustomHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	defer utils.Timer(r.URL)()
+
 	err := h.H(h.E, w, r)
+
 	if err != nil {
 		switch e := err.(type) {
 		case Error:
-			log.Printf("HTTP %d - %s", e.Status(), e)
+			log.Errorf("HTTP %d - %s\n", e.Status(), e)
 			http.Error(w, e.Error(), e.Status())
 		default:
-			log.Printf("Error: %s", err)
+			log.Errorf("Error: %s\n", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		}
 	}

--- a/core/graphelier-service/api/hndlrs/insthandler.go
+++ b/core/graphelier-service/api/hndlrs/insthandler.go
@@ -3,6 +3,8 @@ package hndlrs
 import (
 	"encoding/json"
 	"net/http"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // FetchInstruments : Retrieve available instruments
@@ -11,6 +13,7 @@ func FetchInstruments(env *Env, w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return StatusError{500, err}
 	}
+	log.Debugf("Found %d instruments\n", len(instruments))
 
 	err = json.NewEncoder(w).Encode(instruments)
 	if err != nil {

--- a/core/graphelier-service/api/hndlrs/msghandler.go
+++ b/core/graphelier-service/api/hndlrs/msghandler.go
@@ -8,6 +8,7 @@ import (
 	"graphelier/core/graphelier-service/models"
 
 	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
 )
 
 // FetchMessages returns messages given an instrument and sod_offset with support for
@@ -33,6 +34,7 @@ func FetchMessages(env *Env, w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return StatusError{500, err}
 	}
+	log.Debugf("Found %d messages\n", len(messages))
 
 	responsePaginator := models.Paginator{NMessages: intNMessages, SodOffset: paginator.SodOffset + intNMessages}
 	messagePage := models.MessagePage{PageInfo: responsePaginator, Messages: messages}
@@ -40,7 +42,6 @@ func FetchMessages(env *Env, w http.ResponseWriter, r *http.Request) error {
 	if intNMessages < 0 {
 		reverseMessageOrdering(&messagePage)
 	}
-	w.WriteHeader(http.StatusOK)
 	err = json.NewEncoder(w).Encode(messagePage)
 	if err != nil {
 		return StatusError{500, err}

--- a/core/graphelier-service/db/mongo.go
+++ b/core/graphelier-service/db/mongo.go
@@ -3,10 +3,10 @@ package db
 import (
 	"context"
 	"graphelier/core/graphelier-service/utils"
-	"log"
 
 	"graphelier/core/graphelier-service/models"
 
+	log "github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -65,13 +65,15 @@ func NewConnection() (*Connector, error) {
 		return nil, err
 	}
 
-	log.Println("Connected to MongoDB :)")
+	log.Info("Connected to MongoDB :)\n")
 
 	return c, nil
 }
 
 // GetOrderbook : Finds the Orderbook of an instrument based on the timestamp requested in the db
 func (c *Connector) GetOrderbook(instrument string, timestamp uint64) (result *models.Orderbook, err error) {
+	defer utils.TraceTimer("mongo/GetOrderbook")()
+
 	collection := c.Database("graphelier-db").Collection("orderbooks")
 	filter := bson.D{
 		{Key: "instrument", Value: instrument},
@@ -92,6 +94,8 @@ func (c *Connector) GetOrderbook(instrument string, timestamp uint64) (result *m
 
 // GetMessagesByTimestamp : Finds the Message of an instrument based on the timestamp requested
 func (c *Connector) GetMessagesByTimestamp(instrument string, timestamp uint64) (results []*models.Message, err error) {
+	defer utils.TraceTimer("mongo/GetMessagesByTimestamp")()
+
 	instrumentMeta, found := c.cache.meta[instrument]
 	if !found {
 		return nil, InstrumentNotFoundError{Instrument: instrument}
@@ -134,6 +138,8 @@ func (c *Connector) GetMessagesByTimestamp(instrument string, timestamp uint64) 
 
 // GetMessagesWithPagination returns an messages given an instrument, sod_offset with pagination
 func (c *Connector) GetMessagesWithPagination(instrument string, paginator *models.Paginator) (results []*models.Message, err error) {
+	defer utils.TraceTimer("mongo/GetMessagesWithPagination")()
+
 	collection := c.Database("graphelier-db").Collection("messages")
 	var filterKey string
 	var sortDirection int8
@@ -180,6 +186,8 @@ func (c *Connector) GetMessagesWithPagination(instrument string, paginator *mode
 
 // GetSingleMessage : Returns the message corresponding to the sod_offset (message id)
 func (c *Connector) GetSingleMessage(instrument string, sodOffset int64) (result *models.Message, err error) {
+	defer utils.TraceTimer("mongo/GetSingleMessage")()
+
 	collection := c.Database("graphelier-db").Collection("messages")
 	filter := bson.D{
 		{Key: "instrument", Value: instrument},
@@ -198,8 +206,14 @@ func (c *Connector) GetSingleMessage(instrument string, sodOffset int64) (result
 
 // GetInstruments : Returns available instruments
 func (c *Connector) GetInstruments() (result []string, err error) {
+	defer utils.TraceTimer("mongo/GetInstruments")()
+
 	for r := range c.cache.meta {
 		result = append(result, r)
+	}
+
+	if len(result) == 0 {
+		log.Info("No instruments found in the cache, try refreshing the cache\n")
 	}
 
 	return result, nil
@@ -207,6 +221,8 @@ func (c *Connector) GetInstruments() (result []string, err error) {
 
 // RefreshCache : Updates in-memory cache of meta db values
 func (c *Connector) RefreshCache() error {
+	defer utils.TraceTimer("mongo/RefreshCache")()
+
 	collection := c.Database("graphelier-db").Collection("meta")
 	filter := bson.D{}
 	options := options.Find()

--- a/core/graphelier-service/main.go
+++ b/core/graphelier-service/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"log"
 	"net/http"
 
 	"graphelier/core/graphelier-service/api"
@@ -9,16 +8,23 @@ import (
 	"graphelier/core/graphelier-service/db"
 
 	"github.com/gorilla/handlers"
+	log "github.com/sirupsen/logrus"
+	easy "github.com/t-tomalak/logrus-easy-formatter"
 )
 
 func main() {
+	log.SetFormatter(&easy.Formatter{
+		LogFormat: "[%lvl%]: %time% - %msg%",
+	})
+	log.SetLevel(log.TraceLevel)
+
 	db, err := db.NewConnection()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Could not establish connection to MongoDB: %v\n", err)
 	}
 
 	env := &hndlrs.Env{Connector: db}
 	router := api.NewRouter(env)
 
-	log.Fatal(http.ListenAndServe(":5050", handlers.CORS(handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type", "Authorization"}), handlers.AllowedMethods([]string{"GET", "POST", "PUT", "HEAD", "OPTIONS"}), handlers.AllowedOrigins([]string{"*"}))(router)))
+	log.Fatalln(http.ListenAndServe(":5050", handlers.CORS(handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type", "Authorization"}), handlers.AllowedMethods([]string{"GET", "POST", "PUT", "HEAD", "OPTIONS"}), handlers.AllowedOrigins([]string{"*"}))(router)))
 }

--- a/core/graphelier-service/utils/utils.go
+++ b/core/graphelier-service/utils/utils.go
@@ -1,5 +1,11 @@
 package utils
 
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
 // Abs : Default Abs func for golang takes a float and returns a float. Need one for ints
 func Abs(n int64) int64 {
 	if n < 0 {
@@ -7,3 +13,19 @@ func Abs(n int64) int64 {
 	}
 	return n
 }
+
+func DebugTimer(call interface{}) func() {
+	start := time.Now()
+	return func() {
+		log.Debugf("%s took %v\n", call, time.Since(start))
+	}
+}
+
+func TraceTimer(call interface{}) func() {
+	start := time.Now()
+	return func() {
+		log.Tracef("%s took %v\n", call, time.Since(start))
+	}
+}
+
+var Timer func(interface{}) func() = DebugTimer

--- a/core/graphelier-service/utils/utils.go
+++ b/core/graphelier-service/utils/utils.go
@@ -31,4 +31,4 @@ func TraceTimer(call string) func() {
 }
 
 // Timer : See DebugTimer
-var Timer func(interface{}) func() = DebugTimer
+var Timer func(string) func() = DebugTimer

--- a/core/graphelier-service/utils/utils.go
+++ b/core/graphelier-service/utils/utils.go
@@ -14,18 +14,21 @@ func Abs(n int64) int64 {
 	return n
 }
 
-func DebugTimer(call interface{}) func() {
+// DebugTimer : Returns a deferrable function to log (at DEBUG level) the amount of time taken in the given scope
+func DebugTimer(call string) func() {
 	start := time.Now()
 	return func() {
 		log.Debugf("%s took %v\n", call, time.Since(start))
 	}
 }
 
-func TraceTimer(call interface{}) func() {
+// TraceTimer : Returns a deferrable function to log (at TRACE level) the amount of time taken in the given scope
+func TraceTimer(call string) func() {
 	start := time.Now()
 	return func() {
 		log.Tracef("%s took %v\n", call, time.Since(start))
 	}
 }
 
+// Timer : See DebugTimer
 var Timer func(interface{}) func() = DebugTimer


### PR DESCRIPTION
Using https://github.com/sirupsen/logrus as a logger due to its ease of use and similar API to built-in `log` module.

Added logs to different handlers based on behavior. Also added logs to mongo calls to record performance.

Log format looks like this:
```
[TRACE]: 2020-01-20T23:58:49Z - mongo/RefreshCache took 497.982µs
```