### PR TITLE
[#132] Kontrolol/132/return to recent message

### DIFF
--- a/app/src/components/MessageList.tsx
+++ b/app/src/components/MessageList.tsx
@@ -90,7 +90,8 @@ class MessageList extends Component<Props, State> {
                 this.fetchInitialMessages();
             }
             this.handleScrollBackToSelectedMessage();
-        } else if ((messages[0] && !prevState.messages[0])
+        } else if ((messages[0] && !prevState.messages[0]) // need to check for first time messages loaded
+            // need to check for new messages from new date and time, not from continuous scrolling
             || (messages[0] && prevState.messages[0]
                 && (messages[0].timestamp !== prevState.messages[0].timestamp
                     && messages[messages.length - 1].timestamp

--- a/app/src/components/MessageList.tsx
+++ b/app/src/components/MessageList.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable camelcase */
 import React, { Component, createRef } from 'react';
 import { withStyles, createStyles, WithStyles } from '@material-ui/core/styles';
-import { Box } from '@material-ui/core';
+import { Box, Tooltip } from '@material-ui/core';
+import InfoIcon from '@material-ui/icons/Info';
 import classNames from 'classnames';
 import Button from '@material-ui/core/Button';
 import bigInt from 'big-integer';
@@ -36,6 +37,12 @@ interface State {
     lastSodOffsetTop: bigInt.BigInteger,
     lastSodOffsetBottom: bigInt.BigInteger,
 }
+
+const CustomTooltip = withStyles({
+    tooltip: {
+        fontSize: '0.75rem',
+    },
+})(Tooltip);
 
 class MessageList extends Component<Props, State> {
     selectedMessageItem;
@@ -258,6 +265,9 @@ class MessageList extends Component<Props, State> {
             <div className={classNames(loading ? classes.hide : null, classes.scrollContainer)}>
                 <Box className={classes.tableHeaderRow}>
                     <Box className={classNames(classes.tableColumn, classes.overrideTimestampColumn)}>
+                        <CustomTooltip title={'Click the Tilde ` to manually center to selected message'}>
+                            <InfoIcon />
+                        </CustomTooltip>
                         <div>{'Timestamp'}</div>
                     </Box>
                     <Box className={classes.tableColumn}><div>{'Type'}</div></Box>

--- a/app/src/components/MessageList.tsx
+++ b/app/src/components/MessageList.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import React, { Component } from 'react';
+import React, { Component, createRef } from 'react';
 import { withStyles, createStyles, WithStyles } from '@material-ui/core/styles';
 import { Box } from '@material-ui/core';
 import classNames from 'classnames';
@@ -8,7 +8,7 @@ import bigInt from 'big-integer';
 
 import OrderBookService from '../services/OrderBookService';
 import {
-    MESSAGE_LIST_DEFAULT_PAGE_SIZE,
+    MESSAGE_LIST_DEFAULT_PAGE_SIZE, TILDE_KEY_CODE,
 } from '../constants/Constants';
 import MultiDirectionalScroll from './MultiDirectionalScroll';
 import { Styles } from '../styles/MessageList';
@@ -38,6 +38,8 @@ interface State {
 }
 
 class MessageList extends Component<Props, State> {
+    selectedMessageItem;
+
     constructor(props) {
         super(props);
 
@@ -50,6 +52,7 @@ class MessageList extends Component<Props, State> {
 
     componentDidMount() {
         this.fetchInitialMessages();
+        window.addEventListener('keyup', this.onKeyUp);
     }
 
     shouldComponentUpdate(nextProps: Readonly<Props>, nextState: Readonly<State>, nextContext: any): boolean {
@@ -79,7 +82,18 @@ class MessageList extends Component<Props, State> {
             } else {
                 this.fetchInitialMessages();
             }
+            this.handleScrollBackToSelectedMessage();
+        } else if ((messages[0] && !prevState.messages[0])
+            || (messages[0] && prevState.messages[0]
+                && (messages[0].timestamp !== prevState.messages[0].timestamp
+                    && messages[messages.length - 1].timestamp
+                    !== prevState.messages[prevState.messages.length - 1].timestamp))) {
+            this.handleScrollBackToSelectedMessage();
         }
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('keyup', this.onKeyUp);
     }
 
     /**
@@ -96,6 +110,18 @@ class MessageList extends Component<Props, State> {
         return messages
             .map(message => message.sod_offset)
             .findIndex(sodOffset => sodOffset === lastSodOffset.toString());
+    };
+
+    /**
+     * @desc handles event for scrolling back to the selected message that is being used to determine the orderbook
+     * @returns {void}
+     */
+    private handleScrollBackToSelectedMessage = () => {
+        this.selectedMessageItem && this.selectedMessageItem.current
+        && this.selectedMessageItem.current.scrollIntoView({
+            behavior: 'smooth',
+            block: 'center',
+        });
     };
 
     /**
@@ -125,6 +151,10 @@ class MessageList extends Component<Props, State> {
             console.log(e);
         }
     };
+
+    private onKeyUp = e => {
+        if (e.keyCode === TILDE_KEY_CODE) this.handleScrollBackToSelectedMessage();
+    }
 
     /**
      * @desc Paging handler for upwards and downwards hitting of the multidirectional scroll
@@ -195,9 +225,14 @@ class MessageList extends Component<Props, State> {
             const { timeNanoseconds } = splitNanosecondEpochTimestamp(timestamp);
             const time = nanosecondsToString(convertNanosecondsUTCToCurrentTimezone(bigInt(timeNanoseconds)).valueOf());
 
+            if (lastSodOffset.toString() === sod_offset) {
+                // TODO look into reference callbacks for Typescript
+                this.selectedMessageItem = createRef();
+            }
             return (
                 <Button
                     key={`${sod_offset} ${timestamp}`}
+                    ref={lastSodOffset.toString() === sod_offset ? this.selectedMessageItem : null}
                     className={lastSodOffset.toString() === sod_offset
                         ? classes.currentMessageRow
                         : classes.tableDataRow}
@@ -231,13 +266,15 @@ class MessageList extends Component<Props, State> {
                     <Box className={classes.tableColumn}><div>{'Price'}</div></Box>
                     <Box className={classes.tableColumn}><div>{'Direction'}</div></Box>
                 </Box>
-                <MultiDirectionalScroll
-                    onReachBottom={() => this.handleHitEdge('bottom')}
-                    onReachTop={() => this.handleHitEdge('top')}
-                    position={50}
-                >
-                    {this.renderTableData()}
-                </MultiDirectionalScroll>
+                <div className={classes.messageListContainer}>
+                    <MultiDirectionalScroll
+                        onReachBottom={() => this.handleHitEdge('bottom')}
+                        onReachTop={() => this.handleHitEdge('top')}
+                        position={50}
+                    >
+                        {this.renderTableData()}
+                    </MultiDirectionalScroll>
+                </div>
             </div>
         );
     }

--- a/app/src/components/MessageList.tsx
+++ b/app/src/components/MessageList.tsx
@@ -159,6 +159,10 @@ class MessageList extends Component<Props, State> {
         }
     };
 
+    /**
+     * Handles keypress up in the browser window. Checks for ` in order to center to selected message
+     * @param e
+     */
     private onKeyUp = e => {
         if (e.keyCode === TILDE_KEY_CODE) this.handleScrollBackToSelectedMessage();
     }
@@ -265,7 +269,10 @@ class MessageList extends Component<Props, State> {
             <div className={classNames(loading ? classes.hide : null, classes.scrollContainer)}>
                 <Box className={classes.tableHeaderRow}>
                     <Box className={classNames(classes.tableColumn, classes.overrideTimestampColumn)}>
-                        <CustomTooltip title={'Click the Tilde ` to manually center to selected message'}>
+                        <CustomTooltip
+                            title={'Click tilde ` to center to selected message'}
+                            className={classes.marginRight}
+                        >
                             <InfoIcon />
                         </CustomTooltip>
                         <div>{'Timestamp'}</div>

--- a/app/src/components/MultiDirectionalScroll.tsx
+++ b/app/src/components/MultiDirectionalScroll.tsx
@@ -72,9 +72,9 @@ class MultiDirectionalScroll extends Component<Props> {
             const scrolledUp = scrollTop + offsetTop;
             const scrolledDown = scrolledUp + offsetHeight;
 
-            if (scrolledDown >= bottomEdge) {
+            if (scrolledDown >= (bottomEdge - 5)) {
                 onReachBottom();
-            } else if (scrolledUp <= topEdge) {
+            } else if (scrolledUp <= topEdge + 5) {
                 onReachTop();
             }
         }

--- a/app/src/components/OrderBookSnapshot.tsx
+++ b/app/src/components/OrderBookSnapshot.tsx
@@ -191,14 +191,6 @@ class OrderBookSnapshot extends Component<WithStyles, State> {
     };
 
     /**
-     * @desc Updates the  loadingOrderbook state variable indicating that there is a network call which will change
-     * the contents of the Orderbook.
-     */
-    handleLoadingOrderbook = (loading: boolean) => {
-        this.setState({ loadingOrderbook: loading });
-    }
-
-    /**
      * @desc handles the updates with deltas once a message is moved by a certain amount
      * @param deltas
      */
@@ -418,7 +410,6 @@ class OrderBookSnapshot extends Component<WithStyles, State> {
                             lastSodOffset={lastSodOffset}
                             timeOrDateIsNotSet={selectedTimeNano.equals(0) || selectedDateNano.equals(0)}
                             handleUpdateWithDeltas={this.handleUpdateWithDeltas}
-                            handleLoadingOrderbook={this.handleLoadingOrderbook}
                             instrument={selectedInstrument}
                             loading={loadingOrderbook}
                         />

--- a/app/src/components/TimestampOrderBookScroller.tsx
+++ b/app/src/components/TimestampOrderBookScroller.tsx
@@ -25,7 +25,6 @@ interface Props extends WithStyles<typeof styles> {
     maxQuantity: number
     timeOrDateIsNotSet: boolean,
     lastSodOffset: bigInt.BigInteger,
-    handleLoadingOrderbook: Function,
     handleUpdateWithDeltas: Function,
     instrument: string,
     loading: boolean,
@@ -105,9 +104,8 @@ class TimestampOrderBookScroller extends Component<Props> {
      */
     handleGoToMessageByOffset = (offset: number) => {
         const {
-            lastSodOffset, handleUpdateWithDeltas, instrument, handleLoadingOrderbook,
+            lastSodOffset, handleUpdateWithDeltas, instrument,
         } = this.props;
-        handleLoadingOrderbook(true);
         OrderBookService.getPriceLevelsByMessageOffset(
             instrument,
             lastSodOffset.toString(),
@@ -118,9 +116,6 @@ class TimestampOrderBookScroller extends Component<Props> {
             })
             .catch(err => {
                 console.log(err);
-            })
-            .finally(() => {
-                handleLoadingOrderbook(false);
             });
     };
 

--- a/app/src/constants/Constants.ts
+++ b/app/src/constants/Constants.ts
@@ -9,6 +9,7 @@ export const BACKEND_URL = `http://${host}:${BACKEND_PORT}`;
 
 export const LEFT_ARROW_KEY_CODE = 37;
 export const RIGHT_ARROW_KEY_CODE = 39;
+export const TILDE_KEY_CODE = 192;
 
 export const MESSAGE_LIST_DEFAULT_PAGE_SIZE = 20;
 

--- a/app/src/styles/MessageList.ts
+++ b/app/src/styles/MessageList.ts
@@ -24,6 +24,7 @@ export const Styles = {
         paddingTop: 10,
         paddingBottom: 10,
         backgroundColor: LightThemeColors.palette.primary.main,
+        height: '4.5vh',
     },
     tableColumn: {
         maxWidth: '16.66%',
@@ -44,5 +45,8 @@ export const Styles = {
     },
     hide: {
         background: 'rgba(0,0,0,0.08)',
+    },
+    messageListContainer: {
+        height: '30.5vh',
     },
 };

--- a/app/src/styles/MessageList.ts
+++ b/app/src/styles/MessageList.ts
@@ -49,4 +49,7 @@ export const Styles = {
     messageListContainer: {
         height: '30.5vh',
     },
+    marginRight: {
+        marginRight: '0.25rem',
+    },
 };

--- a/app/src/tests/component-tests/MessageList.test.tsx
+++ b/app/src/tests/component-tests/MessageList.test.tsx
@@ -69,4 +69,24 @@ describe('MessageList', () => {
                 sod_offset: '3',
             });
     });
+
+    it('should detect a scroll to return to selected message', () => {
+        const wrapper = shallow(<MessageList
+            lastSodOffset={LAST_SOD_OFFSET_CLIENT}
+            instrument={INSTRUMENT}
+            handleUpdateWithDeltas={jest.fn()}
+        />);
+
+        wrapper.instance().selectedMessageItem = {
+            current: {
+                scrollIntoView: jest.fn(),
+            },
+        };
+        const scrollSpy = jest.spyOn(wrapper.instance(), 'handleScrollBackToSelectedMessage');
+        expect(scrollSpy).toHaveBeenCalledTimes(0);
+        wrapper.instance().setState({
+            messages: MESSAGE_LIST.messages,
+        });
+        expect(scrollSpy).toHaveBeenCalledTimes(1);
+    });
 });

--- a/app/src/tests/component-tests/TimestampOrderBookScroller.test.tsx
+++ b/app/src/tests/component-tests/TimestampOrderBookScroller.test.tsx
@@ -17,7 +17,6 @@ describe('TimestampOrderbookScroller functionality', () => {
     let mount, shallow;
     const timeOrDateIsNotSet = false;
     const handleUpdateWithDeltas = jest.fn();
-    const handleLoadingOrderbook = jest.fn();
     const loadingOrderbook: boolean = false;
 
     beforeEach(() => {
@@ -33,7 +32,6 @@ describe('TimestampOrderbookScroller functionality', () => {
         const wrapper = mount(<TimestampOrderBookScroller
             timeOrDateIsNotSet={timeOrDateIsNotSet}
             handleUpdateWithDeltas={handleUpdateWithDeltas}
-            handleLoadingOrderbook={handleLoadingOrderbook}
             lastSodOffset={bigInt(0)}
             instrument={INSTRUMENT}
             listItems={ORDER_BOOK_LIST_ITEMS}
@@ -43,7 +41,6 @@ describe('TimestampOrderbookScroller functionality', () => {
         expect(wrapper.props().timeOrDateIsNotSet).toBeDefined();
         expect(wrapper.props().timeOrDateIsNotSet).toEqual(false);
         expect(wrapper.props().handleUpdateWithDeltas).toBeDefined();
-        expect(wrapper.props().handleLoadingOrderbook).toBeDefined();
         expect(wrapper.props().lastSodOffset).toBeDefined();
         expect(wrapper.props().instrument).toBeDefined();
         expect(wrapper.props().instrument).toEqual('SPY');
@@ -58,7 +55,6 @@ describe('TimestampOrderbookScroller functionality', () => {
         const wrapper = shallow(<TimestampOrderBookScroller
             timeOrDateIsNotSet={timeOrDateIsNotSet}
             handleUpdateWithDeltas={handleUpdateWithDeltas}
-            handleLoadingOrderbook={handleLoadingOrderbook}
             lastSodOffset={bigInt(0)}
             instrument={INSTRUMENT}
             listItems={ORDER_BOOK_LIST_ITEMS}
@@ -74,7 +70,6 @@ describe('TimestampOrderbookScroller functionality', () => {
         const wrapper = mount(<TimestampOrderBookScroller
             timeOrDateIsNotSet={timeOrDateIsNotSet}
             handleUpdateWithDeltas={handleUpdateWithDeltas}
-            handleLoadingOrderbook={handleLoadingOrderbook}
             lastSodOffset={bigInt(0)}
             instrument={INSTRUMENT}
             maxQuantity={MAX_QUANTITY}
@@ -87,7 +82,6 @@ describe('TimestampOrderbookScroller functionality', () => {
         const wrapper = mount(<TimestampOrderBookScroller
             timeOrDateIsNotSet={timeOrDateIsNotSet}
             handleUpdateWithDeltas={handleUpdateWithDeltas}
-            handleLoadingOrderbook={handleLoadingOrderbook}
             lastSodOffset={bigInt(0)}
             instrument={INSTRUMENT}
             listItems={ORDER_BOOK_LIST_ITEMS}
@@ -102,7 +96,6 @@ describe('TimestampOrderbookScroller functionality', () => {
         const wrapper = shallow(<TimestampOrderBookScroller
             timeOrDateIsNotSet={timeOrDateIsNotSet}
             handleUpdateWithDeltas={handleUpdateWithDeltas}
-            handleLoadingOrderbook={handleLoadingOrderbook}
             lastSodOffset={bigInt(0)}
             instrument={INSTRUMENT}
             listItems={{}}
@@ -127,7 +120,6 @@ describe('TimestampOrderbookScroller functionality', () => {
         const wrapper = shallow(<TimestampOrderBookScroller
             timeOrDateIsNotSet={timeOrDateIsNotSet}
             handleUpdateWithDeltas={handleUpdateWithDeltas}
-            handleLoadingOrderbook={handleLoadingOrderbook}
             lastSodOffset={bigInt(0)}
             instrument={INSTRUMENT}
             listItems={ORDER_BOOK_LIST_ITEMS}
@@ -164,7 +156,6 @@ describe('TimestampOrderbookScroller functionality', () => {
         const wrapper = mount(<TimestampOrderBookScroller
             timeOrDateIsNotSet={timeOrDateIsNotSet}
             handleUpdateWithDeltas={handleUpdateWithDeltas}
-            handleLoadingOrderbook={handleLoadingOrderbook}
             lastSodOffset={bigInt(0)}
             instrument={INSTRUMENT}
             listItems={ORDER_BOOK_LIST_ITEMS}
@@ -183,7 +174,6 @@ describe('navigating by message functionality', () => {
     let mount, shallow;
     const timeOrDateIsNotSet = false;
     const handleUpdateWithDeltas = jest.fn();
-    const handleLoadingOrderbook = jest.fn();
     const loadingOrderbook: boolean = false;
     const getOrderBookPricesByMessageOffsetSpy = jest.spyOn(OrderBookService, 'getPriceLevelsByMessageOffset')
         .mockImplementation((instrument, timestamp, offset): Promise<any> => Promise.resolve(
@@ -206,7 +196,6 @@ describe('navigating by message functionality', () => {
         const wrapper = shallow(<TimestampOrderBookScroller
             timeOrDateIsNotSet={timeOrDateIsNotSet}
             handleUpdateWithDeltas={handleUpdateWithDeltas}
-            handleLoadingOrderbook={handleLoadingOrderbook}
             lastSodOffset={bigInt(0)}
             instrument={INSTRUMENT}
             listItems={ORDER_BOOK_LIST_ITEMS}


### PR DESCRIPTION
#132
Recentering to the selected message now works after all intuitive manipulations of the visible orderbook
- New message selected
- Traversing messages with the **Forward** and **Backward** arrows
- selecting a new date and time
- Manually via the Tilde `

Issue
- Cannot determine properly to recenter when message selected within < 5 of an edge and **not** recenter when it is simply continuous scrolling from top or bottom.