### PR TITLE
[#164] Force interval_multiple to be an int64

### DIFF
--- a/core/scripts/mongo_db/db_utils.py
+++ b/core/scripts/mongo_db/db_utils.py
@@ -1,5 +1,7 @@
 import math
 
+from bson import Int64
+
 
 def order_book_to_dict(order_book, interval):
     return {
@@ -12,7 +14,7 @@ def order_book_to_dict(order_book, interval):
             "price": price / 10000,
             "orders": [order_to_dict(order) for order in orders]
         } for price, orders in sorted(order_book.ask_book.items())],
-        "interval_multiple": _round_up(order_book.last_time, interval),
+        "interval_multiple": Int64(_round_up(order_book.last_time, interval)),
         "last_sod_offset": order_book.last_sod_offset
     }
 


### PR DESCRIPTION
Small python ints are automatically stored as int32, force conversion into int64 to match service expectations.