### PR TITLE
[#172] Fixed issue with X-axis on window resize

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,7 @@
         "dateformat": "^3.0.3",
         "enzyme": "^3.10.0",
         "enzyme-adapter-react-16": "^1.15.1",
+        "lodash": "^4.17.15",
         "moment": "^2.24.0",
         "nano-date": "^4.1.0",
         "react": "^16.9.0",

--- a/app/src/components/OrderBookSnapshot.tsx
+++ b/app/src/components/OrderBookSnapshot.tsx
@@ -9,6 +9,7 @@ import { WithStyles, createStyles } from '@material-ui/core/styles';
 import MomentUtils from '@date-io/moment';
 import { MuiPickersUtilsProvider, KeyboardDatePicker } from '@material-ui/pickers';
 import bigInt from 'big-integer';
+import { debounce } from 'lodash';
 
 import moment from 'moment';
 import { Styles } from '../styles/OrderBookSnapshot';
@@ -85,6 +86,8 @@ class OrderBookSnapshot extends Component<WithStyles, State> {
         }).finally(() => {
             this.setState({ loadingInstruments: false });
         });
+
+        window.addEventListener('resize', debounce(this.handleResize, 100));
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
@@ -94,10 +97,26 @@ class OrderBookSnapshot extends Component<WithStyles, State> {
         }
     }
 
+    componentWillUnmount() {
+        window.removeEventListener('resize', debounce(this.handleResize, 100));
+    }
+
+
+    /**
+     * @desc Handles window resizing and requests a new number of data points appropriate for the new window width
+     */
+    handleResize = () => {
+        const { selectedDateNano } = this.state;
+        if (selectedDateNano.neq(0)) {
+            const startTime = selectedDateNano.plus(NANOSECONDS_IN_NINE_AND_A_HALF_HOURS);
+            const endTime = selectedDateNano.plus(NANOSECONDS_IN_SIXTEEN_HOURS);
+            this.updateGraphData(startTime, endTime);
+        }
+    };
+
     /**
      * @desc Handles the change in instrument
      * @param event menu item that triggered change
-     * @param child
      */
     handleInstrumentChange = (event: React.ChangeEvent<any>) => {
         this.setState(
@@ -120,7 +139,7 @@ class OrderBookSnapshot extends Component<WithStyles, State> {
      * @returns {number}
      */
     getNumDataPoints = (): number => {
-        return Math.trunc(window.screen.width * NUM_DATA_POINTS_RATIO);
+        return Math.trunc(window.innerWidth * NUM_DATA_POINTS_RATIO);
     };
 
     /**

--- a/app/src/components/OrderBookSnapshot.tsx
+++ b/app/src/components/OrderBookSnapshot.tsx
@@ -52,6 +52,18 @@ interface State {
 }
 
 class OrderBookSnapshot extends Component<WithStyles, State> {
+    /**
+     * @desc Handles window resizing and requests a new number of data points appropriate for the new window width
+     */
+    handleResize = debounce(() => {
+        const { selectedDateNano } = this.state;
+        if (selectedDateNano.neq(0)) {
+            const startTime = selectedDateNano.plus(NANOSECONDS_IN_NINE_AND_A_HALF_HOURS);
+            const endTime = selectedDateNano.plus(NANOSECONDS_IN_SIXTEEN_HOURS);
+            this.updateGraphData(startTime, endTime);
+        }
+    }, 100);
+
     constructor(props) {
         super(props);
 
@@ -87,7 +99,7 @@ class OrderBookSnapshot extends Component<WithStyles, State> {
             this.setState({ loadingInstruments: false });
         });
 
-        window.addEventListener('resize', debounce(this.handleResize, 100));
+        window.addEventListener('resize', this.handleResize);
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
@@ -98,21 +110,8 @@ class OrderBookSnapshot extends Component<WithStyles, State> {
     }
 
     componentWillUnmount() {
-        window.removeEventListener('resize', debounce(this.handleResize, 100));
+        window.removeEventListener('resize', this.handleResize);
     }
-
-
-    /**
-     * @desc Handles window resizing and requests a new number of data points appropriate for the new window width
-     */
-    handleResize = () => {
-        const { selectedDateNano } = this.state;
-        if (selectedDateNano.neq(0)) {
-            const startTime = selectedDateNano.plus(NANOSECONDS_IN_NINE_AND_A_HALF_HOURS);
-            const endTime = selectedDateNano.plus(NANOSECONDS_IN_SIXTEEN_HOURS);
-            this.updateGraphData(startTime, endTime);
-        }
-    };
 
     /**
      * @desc Handles the change in instrument


### PR DESCRIPTION
Fixed issue where X-axis is truncated on the left when the window is resized, and no longer shows 9:30 AM.

Changes:
- Added call to `updateGraphData` when window is resized
- Number of data points requested now depends on window width rather than screen width