### PR TITLE
[#191] Fixed zoom out bug when zoomed in too deep

### DIFF
--- a/app/src/components/TopOfBookGraph.tsx
+++ b/app/src/components/TopOfBookGraph.tsx
@@ -94,7 +94,7 @@ class TopOfBookGraph extends Component<Props> {
                 height={height}
                 ratio={width / height}
                 seriesName={'topOfBook'}
-                pointsPerPxThreshold={1}
+                pointsPerPxThreshold={10}
                 data={topOfBookItems}
                 type={'svg'}
                 xAccessor={xAccessor}


### PR DESCRIPTION
Zooming out once zoomed in too deep is now unblocked.

![zoom_graph](https://user-images.githubusercontent.com/29107916/75600524-40565400-5a7e-11ea-9bf2-d22f94195a86.gif)
