### PR TITLE
[#192] Fixed division by 0 in summarizer

### DIFF
--- a/news/scripts/summarizer.py
+++ b/news/scripts/summarizer.py
@@ -94,6 +94,8 @@ def _rank_sentences(sentences, count_dict):
 
     sent_ranks = []
     for i, sentence in enumerate(sentences):
+        if len(sentence) == 0:
+            continue
         sent_tuple = (i, calculate_score(sentence))
         sent_ranks.append(sent_tuple)
     return sent_ranks


### PR DESCRIPTION
Getting this when running `news_fetcher` on prod:
```
Traceback (most recent call last):
  File "news_fetcher.py", line 228, in <module>
    main()
  File "news_fetcher.py", line 223, in main
    stock_news_fetcher.run()
  File "news_fetcher.py", line 115, in run
    self.articles_enhancer.enhance()
  File "news_fetcher.py", line 190, in enhance
    self._add_nlp_summaries()
  File "news_fetcher.py", line 170, in _add_nlp_summaries
    summary = self.summarize_msk(article.text, NUM_OF_SUMMARIZED_SENTENCES)
  File "/home/ec2-user/graphelier/news/scripts/summarizer.py", line 113, in summarize
    ranked_indexes = _rank_sentences(stemmed_words, word_freq)
  File "/home/ec2-user/graphelier/news/scripts/summarizer.py", line 97, in _rank_sentences
    sent_tuple = (i, calculate_score(sentence))
  File "/home/ec2-user/graphelier/news/scripts/summarizer.py", line 93, in calculate_score
    return score / len(sentence)
```


Solution: in summarizer skip ranking sentences that have length 0.