### PR TITLE
[#218] Set correct timestamp for playback

### DIFF
--- a/app/src/tests/samples/socket_client.js
+++ b/app/src/tests/samples/socket_client.js
@@ -1,8 +1,8 @@
 // eslint-disable-next-line
 const WebSocket = require('ws');
 
-const endpoint = `ws://localhost:5050/playback/SPY/1577892050000000000/?delay=2.0&rateMessages=5`;
-// const endpoint = `ws://localhost:5050/playback/SPY/1577892050000000000/?delay=2.0&rateRealtime=0.5`;
+// const endpoint = `ws://localhost:5050/playback/SPY/1577851200000000000/?delay=2.0&rateRealtime=0.5`;
+const endpoint = `ws://localhost:5050/playback/SPY/1577851200000000000/?delay=2.0&rateMessages=5`;
 console.log(`Connecting to ${endpoint}`);
 const ws = new WebSocket(endpoint);
 

--- a/core/graphelier-service/api/hndlrs/playbackhandler_test.go
+++ b/core/graphelier-service/api/hndlrs/playbackhandler_test.go
@@ -162,7 +162,7 @@ func TestPlaybackSession(t *testing.T) {
 
 	assert.GreaterOrEqual(t, len(socket.Output), 1)
 	result := socket.Output[0].(*models.Modifications)
-	assert.Equal(t, uint64(100), result.Timestamp)
+	assert.Equal(t, uint64(101), result.Timestamp)
 	modification := result.Modifications[0]
 	assert.Equal(t, uint64(1), modification.Offset)
 	assert.Equal(t, models.AddOrderType, modification.Type)

--- a/core/graphelier-service/api/hndlrs/playbackhandler_test.go
+++ b/core/graphelier-service/api/hndlrs/playbackhandler_test.go
@@ -87,6 +87,10 @@ func TestNoRateParam(t *testing.T) {
 	mockedDB := MockDb(t)
 	defer Ctrl.Finish()
 
+	mockedDB.EXPECT().
+		GetSingleMessage("test", int64(1)).
+		Return(pbMessages[0], nil)
+
 	err := MakeRequest(
 		hndlrs.StreamPlayback, // Function under test
 		mockedDB,
@@ -94,7 +98,7 @@ func TestNoRateParam(t *testing.T) {
 		"/playback/test/1",
 		map[string]string{
 			"instrument": "test",
-			"timestamp":  "1",
+			"sodOffset":  "1",
 		},
 		nil,
 	)
@@ -149,12 +153,9 @@ func TestPlaybackSession(t *testing.T) {
 	}
 	mockedDB.EXPECT().
 		GetOrderbook("test", uint64(100)).
-		Return(&models.Orderbook{Timestamp: 100}, nil)
-	mockedDB.EXPECT().
-		GetMessagesByTimestamp("test", uint64(100)).
-		Return([]*models.Message{}, nil)
+		Return(&models.Orderbook{Timestamp: 100, LastSodOffset: 100}, nil)
 
-	err := session.LoadOrderBook(mockedDB, "test", 100)
+	err := session.LoadOrderBook(mockedDB, "test", 100, 100)
 	assert.Nil(t, err)
 
 	err = session.Start() // Function under test

--- a/core/graphelier-service/api/routes.go
+++ b/core/graphelier-service/api/routes.go
@@ -79,7 +79,7 @@ var routes = Routes{
 	Route{
 		"Playback",
 		"GET",
-		"/playback/{instrument}/{timestamp}/",
+		"/playback/{instrument}/{sodOffset}/",
 		hndlrs.CustomHandler{H: hndlrs.StreamPlayback},
 	},
 }

--- a/core/graphelier-service/models/orderbooks.go
+++ b/core/graphelier-service/models/orderbooks.go
@@ -320,5 +320,6 @@ func (orderbook *Orderbook) YieldModifications(messages []*Message) (modificatio
 		}
 		orderbook.ApplyMessage(message)
 	}
+	modifications.Timestamp = orderbook.Timestamp
 	return modifications
 }


### PR DESCRIPTION
Changed request parameter from start timestamp to sod_offset. This will prevent sending duplicate modifications in the first batch when there are multiple messages for the initial timestamp.