### PR TITLE
[#230] Add rate validation in backend

### DIFF
--- a/app/src/components/OrderBookSnapshot.tsx
+++ b/app/src/components/OrderBookSnapshot.tsx
@@ -318,7 +318,6 @@ class OrderBookSnapshot extends Component<Props, State> {
         const data = processOrderBookPlayback(listItems);
         let { newListItems } = data;
         const { newMaxQuantity } = data;
-        console.log(playbackData);
         while (ctr < modificationsLength) {
             const playbackModification = playbackData.modifications[ctr];
             const { price, from, to } = playbackModification;

--- a/app/src/components/PlaybackControl.tsx
+++ b/app/src/components/PlaybackControl.tsx
@@ -177,7 +177,7 @@ class PlaybackControl extends PureComponent<PlaybackProps, PlaybackState> {
         let parameter: string = `?delay=${PLAYBACK_DELAY}&`;
         const speed: number = Number.parseFloat(unitSpeed);
         if (selectedUnit === 'Messages') {
-            parameter = `${parameter}rateMessages=${Math.floor(speed * PLAYBACK_DELAY)}`;
+            parameter = `${parameter}rateMessages=${Math.ceil(speed * PLAYBACK_DELAY)}`;
         } else {
             parameter = `${parameter}rateRealtime=${this.getRealTimeRate()}`;
         }

--- a/core/graphelier-service/api/hndlrs/playbackhandler.go
+++ b/core/graphelier-service/api/hndlrs/playbackhandler.go
@@ -87,8 +87,14 @@ func StreamPlayback(env *Env, w http.ResponseWriter, r *http.Request) error {
 	rateRealtime, tErr := strconv.ParseFloat(getParams.Get("rateRealtime"), 64)
 	switch {
 	case mErr == nil && tErr != nil:
+		if rateMessages == 0 {
+			return StatusError{400, ParamError{"Invalid rateMessages, must be greater than 0"}}
+		}
 		loader = &CountIntervalLoader{Instrument: instrument, Datastore: env.Datastore, Count: rateMessages}
 	case tErr == nil && mErr != nil:
+		if rateRealtime <= 0.0 {
+			return StatusError{400, ParamError{"Invalid rateRealtime, must be greater than 0"}}
+		}
 		loader = &TimeIntervalLoader{
 			Instrument:       instrument,
 			Datastore:        env.Datastore,


### PR DESCRIPTION
- Rate cannot be lower or equal to 0
- Use ceil instead of floor in frontend for message rate